### PR TITLE
replace `futures-util` with `futures-core` & `futures-sink`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ license = "MIT"
 
 [dependencies]
 bytes = "1"
-futures-util = { version = "0.3.14", default-features = false, features = ["sink"] }
+futures-core = "0.3"
+futures-sink = "0.3"
 tokio = { version = "1", default-features = false, features = ["net", "io-util", "rt"] }
 tokio-util = { version = "0.7.1", default-features = false, features = ["codec"] }
 
@@ -56,6 +57,7 @@ rustls-webpki-roots = ["tokio-rustls", "ring", "webpki", "webpki-roots"]
 rustls-native-roots = ["tokio-rustls", "ring", "rustls-native-certs"]
 
 [dev-dependencies]
+futures-util = { version = "0.3.14", default-features = false, features = ["sink"] }
 # For tests
 hyper = { version = "0.14", default-features = false, features = ["client", "http1", "tcp"] }
 # This is just a little bit of performance tuning

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ High performance, strict, tokio-util based websockets implementation.
 
 - Built with tokio-util, intended to be used with tokio from the ground up
 - Minimal dependencies: The base only requires:
-  - tokio, tokio-util, bytes, futures-util (which almost all tokio projects depend on)
+  - tokio, tokio-util, bytes, futures-core, futures-sink
   - SHA1 backend, e.g. sha1_smol (see [Feature flags](#feature-flags))
 - Big selection of features to tailor dependencies to any project (see [Feature flags](#feature-flags))
 - SIMD support: AVX2, SSE2 or NEON for frame (un)masking and accelerated UTF-8 validation


### PR DESCRIPTION
Although `futures-util` is used by a majority of downstream users, not depending upon it speeds up the building of tokio-websockets as it can be scheduled earlier.

This removes the following transient dependencies:

* `futures-task`
* `pun-utils`
* `slab`