### PR TITLE
remove duplicate close message empty states

### DIFF
--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -32,7 +32,7 @@ async fn get_case_count() -> Result<u32, Error> {
     let msg = stream.next().await.unwrap()?;
 
     stream
-        .feed(Message::close(Some(CloseCode::NormalClosure), None))
+        .feed(Message::close(Some(CloseCode::NormalClosure), ""))
         .await
         .unwrap();
     stream.close().await.unwrap();
@@ -52,7 +52,7 @@ async fn update_reports() -> Result<(), Error> {
         .await?;
 
     stream
-        .feed(Message::close(Some(CloseCode::NormalClosure), None))
+        .feed(Message::close(Some(CloseCode::NormalClosure), ""))
         .await?;
     stream.close().await?;
 


### PR DESCRIPTION
Wrapping the reason in an `Option` is unnecessary as `""` is equivalent to `None`. Likewise, wrapping the close code in an `Option` is unnecessary, when receiving one, as `CloseCode::NoStatusReceived` is equivalent to `None`.
