### PR TITLE
rework `CloseCode` into a struct

### DIFF
--- a/src/proto/codec.rs
+++ b/src/proto/codec.rs
@@ -270,7 +270,7 @@ impl Decoder for WebsocketProtocol {
                         .try_into()
                         .unwrap_unchecked()
                 }))?;
-                if !code.is_allowed() {
+                if !code.is_known() || !code.is_sendable() {
                     return Err(Error::Protocol(ProtocolError::DisallowedCloseCode));
                 }
 


### PR DESCRIPTION
By moving to a struct, the internal value becomes private and the only constructor becomes the `TryFrom` implementation. The well-known & sendable close codes are still available as public constants. Close codes returned from the library are available as well.