### PR TITLE
coalesce frame & message limit into payload limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for NEON-accelerated frame (un)masking (currently only on aarch64)
-- Limits for frame and message size can be applied via `{ClientBuilder, ServerBuilder}::limits` to protect against malicious peers
+- Limits for payload length can be applied via `{ClientBuilder, ServerBuilder}::limits` to protect against malicious peers
 - The websocket stream can now be configured via `{ClientBuilder, ServerBuilder}::config`. This currently only supports changing the frame payload size that outgoing messages are chunked into
 
 ### Changed

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,10 +21,8 @@ pub enum Error {
     NoUriConfigured,
     /// Websocket protocol violation.
     Protocol(ProtocolError),
-    /// Frame size limit was exceeded.
-    FrameTooLong { size: usize, max_size: usize },
-    /// Message size limit was exceeded.
-    MessageTooLong { size: usize, max_size: usize },
+    /// Payload length limit was exceeded.
+    PayloadTooLong { len: usize, max_len: usize },
     /// I/O error.
     Io(io::Error),
     /// TLS error originating in [`native_tls`].
@@ -93,17 +91,11 @@ impl fmt::Display for Error {
             #[cfg(feature = "client")]
             Error::NoUriConfigured => f.write_str("client has no URI configured"),
             Error::Protocol(e) => e.fmt(f),
-            Error::FrameTooLong { size, max_size } => {
-                f.write_str("frame size of ")?;
-                size.fmt(f)?;
-                f.write_str(" exceeds frame size limit of ")?;
-                max_size.fmt(f)
-            }
-            Error::MessageTooLong { size, max_size } => {
-                f.write_str("message size of ")?;
-                size.fmt(f)?;
-                f.write_str(" exceeds message size limit of ")?;
-                max_size.fmt(f)
+            Error::PayloadTooLong { len, max_len } => {
+                f.write_str("payload length of ")?;
+                len.fmt(f)?;
+                f.write_str(" exceeds the limit of ")?;
+                max_len.fmt(f)
             }
             Error::Io(e) => e.fmt(f),
             #[cfg(feature = "native-tls")]
@@ -125,8 +117,7 @@ impl std::error::Error for Error {
             Error::AlreadyClosed
             | Error::CannotResolveHost
             | Error::NoUpgradeResponse
-            | Error::FrameTooLong { .. }
-            | Error::MessageTooLong { .. } => None,
+            | Error::PayloadTooLong { .. } => None,
             #[cfg(feature = "client")]
             Error::NoUriConfigured => None,
             Error::Protocol(e) => Some(e),

--- a/src/proto/codec.rs
+++ b/src/proto/codec.rs
@@ -203,13 +203,11 @@ impl Decoder for WebsocketProtocol {
             }
         }
 
-        if let Some(max_frame_size) = self.limits.max_frame_size {
-            if payload_length > max_frame_size {
-                return Err(Error::FrameTooLong {
-                    size: payload_length,
-                    max_size: max_frame_size,
-                });
-            }
+        if payload_length > self.limits.max_payload_len.unwrap_or(usize::MAX) {
+            return Err(Error::PayloadTooLong {
+                len: payload_length,
+                max_len: self.limits.max_payload_len.unwrap_or(usize::MAX),
+            });
         }
 
         // There could be a mask here, but we only load it later,

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -342,12 +342,9 @@ impl From<&ProtocolError> for Message {
 /// [`WebsocketStream`]: super::WebsocketStream
 #[derive(Debug, Clone, Copy)]
 pub struct Limits {
-    /// The maximum allowed frame size. `None` equals no limit. The default is
-    /// 16 MiB.
-    pub(super) max_frame_size: Option<usize>,
-    /// The maximum allowed message size. `None` equals no limit. The default is
-    /// 64 MiB.
-    pub(super) max_message_size: Option<usize>,
+    /// The maximum allowed payload length. `None` equals no limit. The default
+    /// is 64 MiB.
+    pub(super) max_payload_len: Option<usize>,
 }
 
 impl Limits {
@@ -355,25 +352,15 @@ impl Limits {
     #[must_use]
     pub fn unlimited() -> Self {
         Self {
-            max_frame_size: None,
-            max_message_size: None,
+            max_payload_len: None,
         }
     }
 
-    /// Sets the maximum allowed frame size. `None` equals no limit. The default
-    /// is 16 MiB.
-    #[must_use]
-    pub fn max_frame_size(mut self, size: Option<usize>) -> Self {
-        self.max_frame_size = size;
-
-        self
-    }
-
-    /// Sets the maximum allowed message size. `None` equals no limit. The
+    /// Sets the maximum allowed payload length. `None` equals no limit. The
     /// default is 64 MiB.
     #[must_use]
-    pub fn max_message_size(mut self, size: Option<usize>) -> Self {
-        self.max_message_size = size;
+    pub fn max_payload_len(mut self, size: Option<usize>) -> Self {
+        self.max_payload_len = size;
 
         self
     }
@@ -382,8 +369,7 @@ impl Limits {
 impl Default for Limits {
     fn default() -> Self {
         Self {
-            max_frame_size: Some(16 * 1024 * 1024),
-            max_message_size: Some(64 * 1024 * 1024),
+            max_payload_len: Some(64 * 1024 * 1024),
         }
     }
 }


### PR DESCRIPTION
99% of users do not care about imposing a different frame and message size limit.