### PR TITLE
Validate UTF-8 in partial continuation frames

### DIFF
--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -1,69 +1,163 @@
 //! UTF-8 validation and parsing helpers that abstract over [`simdutf8`] if the
 //! `simd` feature is enabled, otherwise fall back to [`std`] equivalents.
+use std::hint::unreachable_unchecked;
+
 use crate::proto::ProtocolError;
 
-/// Converts a slice of bytes to a string slice with SIMD acceleration.
-///
-/// # Errors
-///
-/// Returns a [`ProtocolError`] if the input is invalid UTF-8.
+/// Checks if the passed byte sequence is valid UTF-8 and returns an error if it
+/// isn't.
 #[cfg(feature = "simd")]
-#[inline]
-pub fn parse_str(input: &[u8]) -> Result<&str, ProtocolError> {
-    simdutf8::basic::from_utf8(input).map_err(|_| ProtocolError::InvalidUtf8)
-}
+const FROM_UTF8_BASIC: for<'a> fn(&'a [u8]) -> Result<&'a str, simdutf8::basic::Utf8Error> =
+    simdutf8::basic::from_utf8;
+/// Checks if the passed byte sequence is valid UTF-8 and returns an error with
+/// additional information if it isn't.
+#[cfg(feature = "simd")]
+const FROM_UTF8_COMPAT: for<'a> fn(&'a [u8]) -> Result<&'a str, simdutf8::compat::Utf8Error> =
+    simdutf8::compat::from_utf8;
 
-/// Converts a slice of bytes to a string slice.
-///
-/// # Errors
-///
-/// Returns a [`ProtocolError`] if the input is invalid UTF-8.
+/// Checks if the passed byte sequence is valid UTF-8 and returns an error if it
+/// isn't.
 #[cfg(not(feature = "simd"))]
-#[inline]
-pub fn parse_str(input: &[u8]) -> Result<&str, ProtocolError> {
-    std::str::from_utf8(input).map_err(|_| ProtocolError::InvalidUtf8)
-}
+const FROM_UTF8_BASIC: for<'a> fn(&'a [u8]) -> Result<&'a str, std::str::Utf8Error> =
+    std::str::from_utf8;
+/// Checks if the passed byte sequence is valid UTF-8 and returns an error with
+/// additional information if it isn't.
+#[cfg(not(feature = "simd"))]
+const FROM_UTF8_COMPAT: for<'a> fn(&'a [u8]) -> Result<&'a str, std::str::Utf8Error> =
+    std::str::from_utf8;
 
-/// Retrieve the index of the last valid UTF-8 codepoint with SIMD acceleration.
+/// Converts a slice of bytes to a string slice. This will use SIMD acceleration
+/// if the `simd` crate feature is enabled.
 ///
 /// # Errors
 ///
-/// Returns [`ProtocolError`] if the input is invalid UTF-8 or if the input is
-/// complete but did end on a partial codepoint.
-#[cfg(feature = "simd")]
+/// Returns a [`ProtocolError`] if the input is invalid UTF-8.
 #[inline]
-pub fn should_fail_fast(input: &[u8], is_complete: bool) -> Result<usize, ProtocolError> {
-    // We only need the extra info about the valid codepoints if the frame is
-    // incomplete
-    if is_complete {
-        if simdutf8::basic::from_utf8(input).is_ok() {
-            Ok(input.len())
-        } else {
-            Err(ProtocolError::InvalidUtf8)
-        }
-    } else {
-        match simdutf8::compat::from_utf8(input) {
-            Ok(_) => Ok(input.len()),
-            Err(utf8_error) if utf8_error.error_len().is_some() => Err(ProtocolError::InvalidUtf8),
-            Err(utf8_error) => Ok(utf8_error.valid_up_to()),
+pub fn parse_str(input: &[u8]) -> Result<&str, ProtocolError> {
+    FROM_UTF8_BASIC(input).map_err(|_| ProtocolError::InvalidUtf8)
+}
+
+/// A streaming UTF-8 validator.
+#[derive(Debug)]
+pub(crate) struct Validator {
+    /// Buffer for a partial codepoint. This is four bytes large to copy the
+    /// missing bytes into the buffer and reuse the allocation.
+    partial_codepoint: [u8; 4],
+    /// Length of the partial codepoint currently stored.
+    partial_codepoint_len: usize,
+}
+
+impl Validator {
+    /// Creates a new validator.
+    pub fn new() -> Self {
+        Self {
+            partial_codepoint: [0; 4],
+            partial_codepoint_len: 0,
         }
     }
-}
 
-/// Retrieve the index of the last valid UTF-8 codepoint.
-///
-/// # Errors
-///
-/// Returns [`ProtocolError`] if the input is invalid UTF-8 or if the input is
-/// complete but did end on a partial codepoint.
-#[cfg(not(feature = "simd"))]
-#[inline]
-pub fn should_fail_fast(input: &[u8], is_complete: bool) -> Result<usize, ProtocolError> {
-    match std::str::from_utf8(input) {
-        Ok(_) => Ok(input.len()),
-        Err(utf8_error) if utf8_error.error_len().is_some() || is_complete => {
-            Err(ProtocolError::InvalidUtf8)
+    /// The length of the partial codepoint, once complete.
+    fn complete_codepoint_len(&self) -> usize {
+        // SAFETY: This is guaranteed to be four bytes large
+        match unsafe { self.partial_codepoint.get_unchecked(0) } {
+            // 0b0xxxxxxx (single-byte code point)
+            0b0000_0000..=0b0111_1111 => 1,
+            // 0b110xxxxx (two-byte code point)
+            0b1100_0000..=0b1101_1111 => 2,
+            // 0b1110xxxx (three-byte code point)
+            0b1110_0000..=0b1110_1111 => 3,
+            // 0b11110xxx (four-byte code point)
+            0b1111_0000..=0b1111_0111 => 4,
+            // Invalid first byte.
+            // SAFETY: The first byte must be valid UTF-8, otherwise from_str would return
+            // a FromUtf8Error with error_len() that is Some(_)
+            _ => unsafe { unreachable_unchecked() },
         }
-        Err(utf8_error) => Ok(utf8_error.valid_up_to()),
+    }
+
+    /// Resets the validator state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.partial_codepoint_len = 0;
+    }
+
+    /// Feeds bytes into the streaming validator. Returns `Ok` if the input is
+    /// valid UTF-8, if `is_complete` is true, even if the input has incomplete
+    /// codepoints. Subsequent calls will validate incomplete codepoints
+    /// unless [`Self::reset`] is called in between.
+    pub fn feed(&mut self, input: &[u8], is_complete: bool) -> Result<(), ProtocolError> {
+        // If we have a partial codepoint, complete it
+        let remaining_bytes = if self.partial_codepoint_len == 0 {
+            input
+        } else {
+            let available_bytes = input.len();
+
+            if available_bytes == 0 && !is_complete {
+                return Ok(());
+            }
+
+            let complete_codepoint_len = self.complete_codepoint_len();
+            let missing_bytes = complete_codepoint_len - self.partial_codepoint_len;
+            let bytes_to_copy = available_bytes.min(missing_bytes);
+            let codepoint_len_after_copy = self.partial_codepoint_len + bytes_to_copy;
+
+            // Copy the missing codepoint bytes to the partial codepoint
+            unsafe {
+                self.partial_codepoint
+                    .get_unchecked_mut(self.partial_codepoint_len..codepoint_len_after_copy)
+                    .copy_from_slice(input.get_unchecked(..bytes_to_copy));
+            }
+
+            match FROM_UTF8_COMPAT(unsafe {
+                self.partial_codepoint
+                    .get_unchecked(..codepoint_len_after_copy)
+            }) {
+                Ok(_) => {}
+                Err(utf8_error) if utf8_error.error_len().is_some() => {
+                    return Err(ProtocolError::InvalidUtf8);
+                }
+                Err(_) => {
+                    self.partial_codepoint_len = codepoint_len_after_copy;
+
+                    if is_complete {
+                        return Err(ProtocolError::InvalidUtf8);
+                    }
+
+                    return Ok(());
+                }
+            }
+
+            self.reset();
+
+            unsafe { input.get_unchecked(bytes_to_copy..) }
+        };
+
+        // Validate the entire rest of the input
+        if is_complete {
+            self.reset();
+
+            match FROM_UTF8_BASIC(remaining_bytes) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(ProtocolError::InvalidUtf8),
+            }
+        } else {
+            match FROM_UTF8_COMPAT(remaining_bytes) {
+                Ok(_) => Ok(()),
+                Err(utf8_error) if utf8_error.error_len().is_some() => {
+                    Err(ProtocolError::InvalidUtf8)
+                }
+                Err(utf8_error) => {
+                    // Incomplete input, copy the partial codepoints to the validator
+                    self.partial_codepoint_len = input.len() - utf8_error.valid_up_to();
+                    unsafe {
+                        self.partial_codepoint
+                            .get_unchecked_mut(..self.partial_codepoint_len)
+                            .copy_from_slice(input.get_unchecked(utf8_error.valid_up_to()..));
+                    }
+
+                    Ok(())
+                }
+            }
+        }
     }
 }

--- a/tests/utf8_validation.rs
+++ b/tests/utf8_validation.rs
@@ -1,0 +1,64 @@
+// Autobahn does test all edge cases for UTF-8 validation - except one:
+// When a text message is split into multiple frames and the invalid UTF-8 is
+// part of a continuation frame, it only expects clients to fail fast after the
+// entire frame has been received. We should, however, fail immediately.
+
+use bytes::{BufMut, Bytes, BytesMut};
+use futures_util::StreamExt;
+use tokio::io::{duplex, AsyncWriteExt};
+use tokio_websockets::{proto::ProtocolError, Error, ServerBuilder};
+
+const MASK: [u8; 4] = [0, 0, 0, 0];
+
+fn encode_frame(opcode: u8, payload: &[u8], payload_size: usize, is_final: bool) -> Bytes {
+    let mut dst = BytesMut::new();
+
+    let initial_byte = (u8::from(is_final) << 7) + opcode;
+
+    dst.put_u8(initial_byte);
+
+    if u16::try_from(payload_size).is_err() {
+        dst.put_u8(255);
+        dst.put_u64(payload_size as u64);
+    } else if payload_size > 125 {
+        dst.put_u8(254);
+        dst.put_u16(payload_size as u16);
+    } else {
+        dst.put_u8(payload_size as u8 + 128);
+    }
+
+    dst.extend_from_slice(&MASK);
+
+    dst.extend_from_slice(payload);
+
+    dst.freeze()
+}
+
+#[tokio::test]
+async fn test_utf8_fail_fast_incomplete_continuation() {
+    let (one, mut two) = duplex(usize::MAX);
+    let mut server = ServerBuilder::new().serve(one);
+
+    // [240, 159, 152, 132] is a UTF-8 emoji (grinning face)
+
+    let mut frame1_payload: Vec<u8> = std::iter::repeat_with(|| fastrand::alphanumeric() as u8)
+        .take(4096)
+        .collect();
+    // We omit the last byte of the emoji, since it is *already* invalid at the 0.
+    // This should catch even more edge cases
+    let frame3_payload = [159, 0];
+
+    let frame1 = encode_frame(1, &frame1_payload, 4096, false);
+    frame1_payload[4095] = 240; // Second frame has a trailing partial UTF-8 codepoint
+    let frame2 = encode_frame(0, &frame1_payload, 4096, false);
+    let frame3 = encode_frame(0, &frame3_payload, 4096, false); // Pretend the rest of the payload will be written later
+
+    two.write_all(&frame1).await.unwrap();
+    two.write_all(&frame2).await.unwrap();
+    two.write_all(&frame3).await.unwrap();
+
+    assert!(matches!(
+        server.next().await,
+        Some(Err(Error::Protocol(ProtocolError::InvalidUtf8)))
+    ));
+}


### PR DESCRIPTION
This refactors the UTF-8 validation into a streaming validator which keeps track of partial codepoints.