### PR TITLE
empty default features

### DIFF
--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -27,13 +27,13 @@ jobs:
 
       - name: Build tokio-websockets (SIMD)
         run: |
-          cargo build --release --examples --features simd
+          cargo build --release --example autobahn_client --example autobahn_server --features client,fastrand,server,sha1_smol,simd
           mv target/x86_64-unknown-linux-gnu/release/examples/autobahn_client target/x86_64-unknown-linux-gnu/release/examples/autobahn_client_simd
           mv target/x86_64-unknown-linux-gnu/release/examples/autobahn_server target/x86_64-unknown-linux-gnu/release/examples/autobahn_server_simd
 
       - name: Build tokio-websockets (no SIMD)
         run: |
-          cargo build --release --examples
+          cargo build --release --example autobahn_client --example autobahn_server --features client,fastrand,server,sha1_smol
 
       - name: Build tokio-tungstenite
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[breaking]** `WebsocketStream` is now fully cancellation safe and implements `Stream`, therefore using `WebsocketStream::next` now requires having `StreamExt` in scope
 - **[breaking]** `CloseCode` is now a wrapper around a `NonZeroU16` instead of an enum. Enum variants have been moved to associated constants. This fixes possible creation of disallowed close codes by the user
 - **[breaking]** All error types are now marked as `non_exhaustive` to prevent consumer build breakage when new variants are added
+- **[breaking]** Emptied default features
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ webpki = { package = "rustls-webpki", version = "0.101", optional = true }
 openssl = { version = "0.10", default-features = false, optional = true }
 
 [features]
-default = ["client", "fastrand", "server", "sha1_smol"]
 client = ["dep:base64", "dep:http", "dep:httparse", "tokio/net", "tokio/io-util", "tokio/rt"]
 http-integration = ["dep:http-body"]
 server = ["dep:base64", "dep:http", "dep:httparse", "tokio/io-util"]
@@ -65,8 +64,36 @@ tokio = { version = "1", default-features = false, features = ["net", "macros", 
 tokio-rustls = "0.24"
 
 [[example]]
+name = "autobahn_client"
+required-features = ["client"]
+
+[[example]]
+name = "autobahn_server"
+required-features = ["server"]
+
+[[example]]
+name = "client"
+required-features = ["client"]
+
+[[example]]
 name = "native_tls_self_signed_client"
-required-features = ["native-tls"]
+required-features = ["client", "native-tls"]
+
+[[example]]
+name = "rustls_server"
+required-features = ["server"]
+
+[[example]]
+name = "server"
+required-features = ["server"]
+
+[[example]]
+name = "utf8_benchmark_client"
+required-features = ["client"]
+
+[[example]]
+name = "utf8_benchmark_server"
+required-features = ["server"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -40,18 +40,9 @@ One SHA1 implementation is required, usually provided by the TLS implementation:
 
 The `client` feature requires enabling one random number generator:
 
-- [`fastrand`](https://docs.rs/fastrand/latest/fastrand) is the default used and a `PRNG`
+- [`fastrand`](https://docs.rs/fastrand/latest/fastrand) can be used as a `PRNG`
 - [`getrandom`](https://docs.rs/getrandom/latest/getrandom) can be used as a cryptographically secure RNG
 - [`rand`](https://docs.rs/rand/latest/rand) can be used as an alternative to `fastrand` and should be preferred if it is already in the dependency tree
-
-For these reasons, I recommend disabling default features and using a configuration that makes sense for you, for example:
-
-```toml
-# Tiny client
-tokio-websockets = { version = "*", default-features = false, features = ["client", "fastrand", "sha1_smol"] }
-# Client with SIMD, cryptographically secure RNG and rustls
-tokio-websockets = { version = "*", default-features = false, features = ["client", "getrandom", "simd", "rustls-webpki-roots"] }
-```
 
 ## Example
 

--- a/tests/cancellation_safety.rs
+++ b/tests/cancellation_safety.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "server")]
 use std::{
     io,
     pin::Pin,

--- a/tests/utf8_validation.rs
+++ b/tests/utf8_validation.rs
@@ -2,6 +2,7 @@
 // When a text message is split into multiple frames and the invalid UTF-8 is
 // part of a continuation frame, it only expects clients to fail fast after the
 // entire frame has been received. We should, however, fail immediately.
+#![cfg(feature = "server")]
 
 use bytes::{BufMut, Bytes, BytesMut};
 use futures_util::StreamExt;


### PR DESCRIPTION
Speeds up compilation without having to (verbosely) specify `no-default-features = true` and forces users to reason about their optimal RNG & SHA1 impls.

Resolves #11.
