### PR TITLE
docs: add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # tokio-websockets
 
+[![Crates.io](https://img.shields.io/crates/v/tokio-websockets.svg?maxAge=2592000)](https://crates.io/crates/tokio-websockets)
+![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/Gelbpunkt/tokio-websockets/ci.yml)
+[![Documentation](https://img.shields.io/docsrs/tokio-websockets)](https://docs.rs/tokio-websockets)
+
 High performance, strict, tokio-util based websockets implementation.
 
 ## Why use tokio-websockets?


### PR DESCRIPTION
Adds fancy badges to the top of the readme. One for the check build action, one for crates.io, and one for docs.rs.

Motivation: I was visiting this repo often and it was getting slightly annoying not having a link to the docs.rs anywhere 😅. I thought I'd add some other common badges too whilst I was at it. If you don't like them then feel free to just close this PR.