### PR TITLE
Do not wait for stream closure in poll_close

### DIFF
--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -411,7 +411,6 @@ where
         {
             self.queue_frame(Frame::DEFAULT_CLOSE);
         }
-        while ready!(self.as_mut().poll_next(cx)).is_some() {}
 
         ready!(self.as_mut().poll_flush(cx))?;
         Pin::new(self.inner.get_mut())


### PR DESCRIPTION
This actually made the README.md example fail with `Io(Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" })`  at the `poll_shutdown` part!

Reasoning: 
* The `poll_flush` calls ensure the close frame gets written, and `poll_next` calls `poll_flush` via `poll_next_frame`
-> So essentially this already writes the close frame
* Then, the `poll_next` loop waits for the connection to be terminated (indicated by the `None` return value)
* This results in the remote end having closed the connection already, so the following `poll_flush` is useless and `poll_shutdown` will obviously give an I/O error

Solution: Let `poll_flush` write the close frame and ensure that `poll_shutdown` operates on a connected stream. `poll_close` does not have to wait for the stream to terminate as per the documentation in `futures-sink`