### PR TITLE
Fix close sequence, take #2

### DIFF
--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -68,8 +68,6 @@ async fn run_test(case: u32) -> Result<(), Error> {
         }
     }
 
-    stream.close().await?;
-
     Ok(())
 }
 

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -32,8 +32,6 @@ async fn handle_connection(stream: TcpStream) -> Result<(), Error> {
         }
     }
 
-    ws_stream.close().await?;
-
     Ok(())
 }
 

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -335,9 +335,7 @@ where
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
-        if !(self.state == StreamState::Active
-            || matches!(self.state, StreamState::ClosedByPeer if item.is_close()))
-        {
+        if self.state != StreamState::Active {
             return Err(Error::AlreadyClosed);
         }
 

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -211,12 +211,8 @@ where
 
     /// Masks and queues a frame for sending when [`poll_flush`] gets called.
     fn queue_frame(&mut self, frame: Frame) {
-        if frame.opcode == OpCode::Close {
-            if self.state == StreamState::ClosedByPeer {
-                self.state = StreamState::CloseAcknowledged;
-            } else {
-                self.state = StreamState::ClosedByUs;
-            }
+        if frame.opcode == OpCode::Close && self.state != StreamState::ClosedByPeer {
+            self.state = StreamState::ClosedByUs;
         }
 
         let (frame, mask): (Frame, Option<[u8; 4]>) = if self.inner.codec().role == Role::Client {

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -345,7 +345,7 @@ where
             return Err(Error::AlreadyClosed);
         }
 
-        if item.opcode.is_control() {
+        if item.opcode.is_control() || item.payload.len() <= self.config.frame_size {
             let frame: Frame = item.into();
             self.queue_frame(frame);
         } else {


### PR DESCRIPTION
Alternative to #34 

By logging I observed that we never actually entered the `StreamState` that was supposed to be reached. This moves the state tracking to `queue_frame`, which in turn allows for removing a lot of the checks. Also, the end responsible for responding to a close frame would previously never flush the sink after queueing a response close frame. This is all resolved now.