### PR TITLE
Adds a `From<Payload> for Bytes` impl

### DIFF
--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -257,6 +257,15 @@ impl From<BytesMut> for Payload {
     }
 }
 
+impl From<Payload> for Bytes {
+    fn from(value: Payload) -> Self {
+        match value.0.into_inner() {
+            PayloadStorage::Unique(p) => p.freeze(),
+            PayloadStorage::Shared(p) => p,
+        }
+    }
+}
+
 impl From<String> for Payload {
     fn from(value: String) -> Self {
         // Possible options:


### PR DESCRIPTION
This is useful for cases where:

  * The `BytesMut` optimization is not needed.
  * The `!Sync` `Payload` is cumbersome, making references `!Send`.

`Bytes` are already effectively part of the API (in the other direction).