### PR TITLE
Track whether text message payload was utf8-validated

### DIFF
--- a/src/proto/codec.rs
+++ b/src/proto/codec.rs
@@ -16,7 +16,7 @@ use crate::{
     mask,
     proto::ProtocolError,
     utf8::{self, Validator},
-    CloseCode, Error,
+    CloseCode, Error, Payload,
 };
 
 /// The actual implementation of the WebSocket byte-level protocol.
@@ -266,7 +266,8 @@ impl Decoder for WebSocketProtocol {
         // Advance the offset into the payload body
         src.advance(offset);
         // Take the payload
-        let payload = src.split_to(payload_length).into();
+        let mut payload = Payload::from(src.split_to(payload_length));
+        payload.set_utf8_validated(opcode == OpCode::Text && fin);
 
         // It is possible to receive intermediate control frames between a large other
         // frame. We therefore can't simply reset the fragmented opcode after we receive

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -299,7 +299,8 @@ where
         }
 
         let opcode = replace(&mut self.partial_opcode, OpCode::Continuation);
-        let payload = take(&mut self.partial_payload).into();
+        let mut payload = Payload::from(take(&mut self.partial_payload));
+        payload.set_utf8_validated(opcode == OpCode::Text);
 
         Poll::Ready(Some(Ok(Message { opcode, payload })))
     }


### PR DESCRIPTION
Fixes an UB when users create a Message::text from invalid UTF-8 and then call Message::as_text on it. This should never be done anyways, so we simply panic if that is the case.