### PR TITLE
Add support for rustls-platform-verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           cargo hack check \
             --feature-powerset \
             --no-dev-deps \
-            --exclude-features nightly \
+            --exclude-features aws-lc-rs,nightly \
             --group-features client,fastrand,sha1_smol \
             --group-features server,sha1_smol
 
@@ -252,6 +252,6 @@ jobs:
             --target aarch64-unknown-linux-gnu \
             --feature-powerset \
             --no-dev-deps \
-            --exclude-features nightly \
+            --exclude-features aws-lc-rs,nightly \
             --group-features client,fastrand,sha1_smol \
             --group-features server,sha1_smol

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"]
 ring = { version = "0.17", default-features = false, optional = true }
 rustls-native-certs = { version = "0.7", default-features = false, optional = true }
 rustls-pki-types = { version = "1", optional = true }
+rustls-platform-verifier = { version = "0.3", optional = true }
 tokio-rustls = { version = "0.26", default-features = false, optional = true }
 webpki-roots = { version = "0.26", default-features = false, optional = true }
 
@@ -60,6 +61,7 @@ simd = ["dep:simdutf8"]
 native-tls = ["dep:tokio-native-tls"]
 rustls-webpki-roots = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:webpki-roots"]
 rustls-native-roots = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:rustls-native-certs"]
+rustls-platform-verifier = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:rustls-platform-verifier"]
 rustls-tls12 = ["tokio-rustls?/tls12"]
 nightly = ["simdutf8?/aarch64_neon_prefetch"]
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ TLS is supported via any of the following feature flags:
 - `native-tls` for a [`tokio-native-tls`](https://docs.rs/tokio-native-tls/latest/tokio_native_tls/) backed implementation
 - `rustls-webpki-roots` for a [`tokio-rustls`](https://docs.rs/tokio-rustls/latest/tokio_rustls/) backed implementation with [`webpki-roots`](https://docs.rs/webpki-roots/latest/webpki_roots/)
 - `rustls-native-roots` for a [`tokio-rustls`](https://docs.rs/tokio-rustls/latest/tokio_rustls/) backed implementation with [`rustls-native-certs`](https://docs.rs/rustls-native-certs/latest/rustls_native_certs/)
+- `rustls-platform-verifier` for a [`tokio-rustls`](https://docs.rs/tokio-rustls/latest/tokio_rustls/) backed implementation with [`rustls-platform-verifier`](https://docs.rs/rustls-native-certs/latest/rustls_platform_verifier/)
 
 The `rustls-*-roots` features require a crypto provider for `rustls`. You can either enable the `aws_lc_rs` (optionally also FIPS-compliant via the `fips` feature) or `ring` features to use these crates as the providers and then use `TlsConnector::new()`, or bring your own with `TlsConnector::new_rustls_with_crypto_provider()`.
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ TLS is supported via any of the following feature flags:
 - `native-tls` for a [`tokio-native-tls`](https://docs.rs/tokio-native-tls/latest/tokio_native_tls/) backed implementation
 - `rustls-webpki-roots` for a [`tokio-rustls`](https://docs.rs/tokio-rustls/latest/tokio_rustls/) backed implementation with [`webpki-roots`](https://docs.rs/webpki-roots/latest/webpki_roots/)
 - `rustls-native-roots` for a [`tokio-rustls`](https://docs.rs/tokio-rustls/latest/tokio_rustls/) backed implementation with [`rustls-native-certs`](https://docs.rs/rustls-native-certs/latest/rustls_native_certs/)
-- `rustls-platform-verifier` for a [`tokio-rustls`](https://docs.rs/tokio-rustls/latest/tokio_rustls/) backed implementation with [`rustls-platform-verifier`](https://docs.rs/rustls-native-certs/latest/rustls_platform_verifier/)
+- `rustls-platform-verifier` for a [`tokio-rustls`](https://docs.rs/tokio-rustls/latest/tokio_rustls/) backed implementation with [`rustls-platform-verifier`](https://docs.rs/rustls-platform-verifier/latest/rustls_platform_verifier/)
 
-The `rustls-*-roots` features require a crypto provider for `rustls`. You can either enable the `aws_lc_rs` (optionally also FIPS-compliant via the `fips` feature) or `ring` features to use these crates as the providers and then use `TlsConnector::new()`, or bring your own with `TlsConnector::new_rustls_with_crypto_provider()`.
+The `rustls-*-roots` and `rustls-platform-verifier` features require a crypto provider for `rustls`. You can either enable the `aws_lc_rs` (optionally also FIPS-compliant via the `fips` feature) or `ring` features to use these crates as the providers and then use `TlsConnector::new()`, or bring your own with `TlsConnector::new_rustls_with_crypto_provider()`.
 
 One SHA1 implementation is required, usually provided by the TLS implementation:
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -253,13 +253,21 @@ impl<'a, R: Resolver> Builder<'a, R> {
                 connector.wrap(host, stream).await?
             } else {
                 #[cfg(all(
-                    any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"),
+                    any(
+                        feature = "rustls-webpki-roots",
+                        feature = "rustls-native-roots",
+                        feature = "rustls-platform-verifier"
+                    ),
                     not(any(feature = "ring", feature = "aws_lc_rs"))
                 ))]
                 return Err(Error::NoTlsConnectorConfigured);
 
                 #[cfg(not(all(
-                    any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"),
+                    any(
+                        feature = "rustls-webpki-roots",
+                        feature = "rustls-native-roots",
+                        feature = "rustls-platform-verifier"
+                    ),
                     not(any(feature = "ring", feature = "aws_lc_rs"))
                 )))]
                 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,11 @@
 //! General error type used in the crate.
 use std::{fmt, io};
 
-#[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+#[cfg(any(
+    feature = "rustls-webpki-roots",
+    feature = "rustls-native-roots",
+    feature = "rustls-platform-verifier"
+))]
 use rustls_pki_types::InvalidDnsNameError;
 #[cfg(feature = "native-tls")]
 use tokio_native_tls::native_tls;
@@ -29,10 +33,18 @@ pub enum Error {
     #[cfg(feature = "native-tls")]
     NativeTls(native_tls::Error),
     /// Attempted to connect to an invalid DNS name.
-    #[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+    #[cfg(any(
+        feature = "rustls-webpki-roots",
+        feature = "rustls-native-roots",
+        feature = "rustls-platform-verifier"
+    ))]
     InvalidDNSName(InvalidDnsNameError),
     /// A general rustls error.
-    #[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+    #[cfg(any(
+        feature = "rustls-webpki-roots",
+        feature = "rustls-native-roots",
+        feature = "rustls-platform-verifier"
+    ))]
     Rustls(tokio_rustls::rustls::Error),
     /// An unsupported, i.e. not `ws` or `wss`, or no URI scheme was specified.
     #[cfg(feature = "client")]
@@ -43,7 +55,11 @@ pub enum Error {
     /// Rustls was enabled via crate features, but no crypto provider was
     /// configured prior to connecting.
     #[cfg(all(
-        any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"),
+        any(
+            feature = "rustls-webpki-roots",
+            feature = "rustls-native-roots",
+            feature = "rustls-platform-verifier"
+        ),
         not(any(feature = "ring", feature = "aws_lc_rs"))
     ))]
     NoTlsConnectorConfigured,
@@ -68,14 +84,22 @@ impl From<io::Error> for Error {
     }
 }
 
-#[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+#[cfg(any(
+    feature = "rustls-webpki-roots",
+    feature = "rustls-native-roots",
+    feature = "rustls-platform-verifier"
+))]
 impl From<InvalidDnsNameError> for Error {
     fn from(err: InvalidDnsNameError) -> Self {
         Self::InvalidDNSName(err)
     }
 }
 
-#[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+#[cfg(any(
+    feature = "rustls-webpki-roots",
+    feature = "rustls-native-roots",
+    feature = "rustls-platform-verifier"
+))]
 impl From<tokio_rustls::rustls::Error> for Error {
     fn from(err: tokio_rustls::rustls::Error) -> Self {
         Self::Rustls(err)
@@ -108,16 +132,28 @@ impl fmt::Display for Error {
             Error::Io(e) => e.fmt(f),
             #[cfg(feature = "native-tls")]
             Error::NativeTls(e) => e.fmt(f),
-            #[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+            #[cfg(any(
+                feature = "rustls-webpki-roots",
+                feature = "rustls-native-roots",
+                feature = "rustls-platform-verifier"
+            ))]
             Error::InvalidDNSName(_) => f.write_str("invalid DNS name"),
-            #[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+            #[cfg(any(
+                feature = "rustls-webpki-roots",
+                feature = "rustls-native-roots",
+                feature = "rustls-platform-verifier"
+            ))]
             Error::Rustls(e) => e.fmt(f),
             #[cfg(feature = "client")]
             Error::UnsupportedScheme => f.write_str("unsupported or no URI scheme used"),
             #[cfg(any(feature = "client", feature = "server"))]
             Error::Upgrade(e) => e.fmt(f),
             #[cfg(all(
-                any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"),
+                any(
+                    feature = "rustls-webpki-roots",
+                    feature = "rustls-native-roots",
+                    feature = "rustls-platform-verifier"
+                ),
                 not(any(feature = "ring", feature = "aws_lc_rs"))
             ))]
             Error::NoTlsConnectorConfigured => {
@@ -134,7 +170,11 @@ impl std::error::Error for Error {
             #[cfg(feature = "client")]
             Error::NoUriConfigured => None,
             #[cfg(all(
-                any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"),
+                any(
+                    feature = "rustls-webpki-roots",
+                    feature = "rustls-native-roots",
+                    feature = "rustls-platform-verifier"
+                ),
                 not(any(feature = "ring", feature = "aws_lc_rs"))
             ))]
             Error::NoTlsConnectorConfigured => None,
@@ -144,9 +184,17 @@ impl std::error::Error for Error {
             Error::Io(e) => Some(e),
             #[cfg(feature = "native-tls")]
             Error::NativeTls(e) => Some(e),
-            #[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+            #[cfg(any(
+                feature = "rustls-webpki-roots",
+                feature = "rustls-native-roots",
+                feature = "rustls-platform-verifier"
+            ))]
             Error::InvalidDNSName(e) => Some(e),
-            #[cfg(any(feature = "rustls-webpki-roots", feature = "rustls-native-roots"))]
+            #[cfg(any(
+                feature = "rustls-webpki-roots",
+                feature = "rustls-native-roots",
+                feature = "rustls-platform-verifier"
+            ))]
             Error::Rustls(e) => Some(e),
             #[cfg(any(feature = "client", feature = "server"))]
             Error::Upgrade(e) => Some(e),


### PR DESCRIPTION
I somehow missed this. We can add this and release 0.8.1 with it.