### PR TITLE
MSRV bump to 1.79 and other breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,10 +204,10 @@ jobs:
           crate: cargo-hack
           locked: false
 
-      - name: Install 1.64.0 toolchain
+      - name: Install 1.79.0 toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.64.0
+          toolchain: 1.79.0
           targets: aarch64-unknown-linux-gnu
 
       - name: Cache dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "High performance, strict, tokio-util based WebSockets implementation"
 categories = ["web-programming::websocket", "network-programming", "asynchronous", "concurrency"]
 repository = "https://github.com/Gelbpunkt/tokio-websockets/"
-rust-version = "1.64"
+rust-version = "1.79"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1"
+bytes = "1.7"
 futures-core = "0.3"
 futures-sink = "0.3"
 tokio = "1"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ async fn main() -> Result<(), Error> {
 
 ## MSRV
 
-The current MSRV for all feature combinations is Rust 1.64.
+The current MSRV for all feature combinations is Rust 1.79.
 
 ## Caveats / Limitations / ToDo
 

--- a/src/proto/codec.rs
+++ b/src/proto/codec.rs
@@ -210,8 +210,8 @@ impl Decoder for WebSocketProtocol {
                     let (masking_key, rest_of_payload) = src
                         .get_unchecked_mut(offset - 4..)
                         .split_at_mut_unchecked(4);
-                    let payload_masked = rest_of_payload
-                        .get_unchecked_mut(self.payload_processed..payload_available);
+                    let payload_masked =
+                        rest_of_payload.get_unchecked_mut(self.payload_processed..payload_length);
 
                     mask::frame(masking_key, payload_masked, self.payload_processed & 3);
                 };

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -217,10 +217,7 @@ where
             #[cfg(feature = "client")]
             {
                 let mut frame = frame;
-                let mut payload = match frame.payload.try_into_bytesmut() {
-                    Ok(b) => b,
-                    Err(b) => BytesMut::from(&*b),
-                };
+                let mut payload = BytesMut::from(frame.payload);
                 let mask = crate::rand::get_mask();
                 crate::mask::frame(&mask, &mut payload, 0);
                 frame.payload = Payload::from(payload);
@@ -285,8 +282,7 @@ where
             // That is indicated by partial_payload being empty
             if self.partial_payload.is_empty() {
                 // First frame of a multi-frame message
-                // SAFETY: Received payloads are always internally represented as BytesMut
-                self.partial_payload = unsafe { payload.try_into_bytesmut().unwrap_unchecked() };
+                self.partial_payload = BytesMut::from(payload);
             } else {
                 self.partial_payload.extend_from_slice(&payload);
             }

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -148,13 +148,18 @@ impl TryFrom<u16> for CloseCode {
 /// wrapper around [`Bytes`] and [`BytesMut`].
 ///
 /// Payloads can be created by using the `From<T>` implementations. All of them
-/// except the [`From<BytesMut>`] implementation use [`Bytes`] under the hood.
+/// use [`BytesMut`] under the hood, except when created using [`From<Bytes>`]
+/// with a reference counter greater than one.
 ///
 /// Sending the payloads is zero-copy, except when sending a payload backed by
 /// [`Bytes`] as a client to a server. The use of [`BytesMut`] as the backing
 /// storage where cheaply possible is recommended to ensure zero-copy sending.
 ///
-/// [`From<BytesMut>`]: #impl-From<BytesMut>-for-Payload
+/// All conversions to other types are zero-cost, except [`Into<BytesMut>`] if
+/// the backing type is [`Bytes`] with a reference counter greater than one.
+///
+/// [`From<Bytes>`]: #impl-From<Bytes>-for-Payload
+/// [`Into<BytesMut>`]: #impl-From<Payload>-for-BytesMut    
 pub struct Payload {
     /// The raw payload data.
     data: UnsafeCell<PayloadStorage>,

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -149,7 +149,7 @@ impl TryFrom<u16> for CloseCode {
 ///
 /// Payloads can be created by using the `From<T>` implementations. All of them
 /// use [`BytesMut`] under the hood, except when created using [`From<Bytes>`]
-/// with a reference counter greater than one.
+/// with a reference counter greater than one or when using a static reference.
 ///
 /// Sending the payloads is zero-copy, except when sending a payload backed by
 /// [`Bytes`] as a client to a server. The use of [`BytesMut`] as the backing


### PR DESCRIPTION
Some breaking changes for MSRV 1.79 and bytes 1.7 bump while I'm at the breaking changes stuff for a new release...

Why 1.79? Stabilized `split_at_mut_unchecked` which lets us get rid of pointers

Note that this adds `From<Payload>` for `BytesMut` as a public API, yet I think this is less problematic now that the conversion is much cheaper due to `bytes` making it free if the ref counter is 1.