### PR TITLE
Respect rustls default crypto providers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -259,29 +259,9 @@ impl<'a, R: Resolver> Builder<'a, R> {
             if let Some(connector) = self.connector {
                 connector.wrap(host, stream).await?
             } else {
-                #[cfg(all(
-                    any(
-                        feature = "rustls-webpki-roots",
-                        feature = "rustls-native-roots",
-                        feature = "rustls-platform-verifier"
-                    ),
-                    not(any(feature = "ring", feature = "aws_lc_rs"))
-                ))]
-                return Err(Error::NoTlsConnectorConfigured);
+                let connector = Connector::new()?;
 
-                #[cfg(not(all(
-                    any(
-                        feature = "rustls-webpki-roots",
-                        feature = "rustls-native-roots",
-                        feature = "rustls-platform-verifier"
-                    ),
-                    not(any(feature = "ring", feature = "aws_lc_rs"))
-                )))]
-                {
-                    let connector = Connector::new()?;
-
-                    connector.wrap(host, stream).await?
-                }
+                connector.wrap(host, stream).await?
             }
         } else if uri.scheme_str() == Some("ws") {
             Connector::Plain.wrap(host, stream).await?

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,8 @@ pub enum Error {
     #[cfg(any(feature = "client", feature = "server"))]
     Upgrade(crate::upgrade::Error),
     /// Rustls was enabled via crate features, but no crypto provider was
-    /// configured prior to connecting.
+    /// configured via [`rustls::crypto::CryptoProvider::install_default`]
+    /// prior to connecting.
     #[cfg(all(
         any(
             feature = "rustls-webpki-roots",
@@ -62,7 +63,7 @@ pub enum Error {
         ),
         not(any(feature = "ring", feature = "aws_lc_rs"))
     ))]
-    NoTlsConnectorConfigured,
+    NoCryptoProviderConfigured,
 }
 
 #[cfg(feature = "native-tls")]
@@ -156,7 +157,7 @@ impl fmt::Display for Error {
                 ),
                 not(any(feature = "ring", feature = "aws_lc_rs"))
             ))]
-            Error::NoTlsConnectorConfigured => {
+            Error::NoCryptoProviderConfigured => {
                 f.write_str("wss uri set but no tls connector was configured")
             }
         }
@@ -177,7 +178,7 @@ impl std::error::Error for Error {
                 ),
                 not(any(feature = "ring", feature = "aws_lc_rs"))
             ))]
-            Error::NoTlsConnectorConfigured => None,
+            Error::NoCryptoProviderConfigured => None,
             #[cfg(feature = "client")]
             Error::UnsupportedScheme => None,
             Error::Protocol(e) => Some(e),


### PR DESCRIPTION
This is a great fallback option if no crypto provider is configured via crate features. It allows for `Connector::new` always being available, which is really nice for consumer crates. Sadly, this is a breaking change due to the error enum changes.