### PR TITLE
Update rustls-native-certs to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tokio-native-tls = { version = "0.3", optional = true }
 # Rustls
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"], optional = true }
 ring = { version = "0.17", default-features = false, optional = true }
-rustls-native-certs = { version = "0.7", default-features = false, optional = true }
+rustls-native-certs = { version = "0.8", default-features = false, optional = true }
 rustls-pki-types = { version = "1", optional = true }
 rustls-platform-verifier = { version = "0.3.1", optional = true }
 tokio-rustls = { version = "0.26", default-features = false, optional = true }


### PR DESCRIPTION
rustls-native-certs now returns much more fine grained errors. I would consider *some* errors to be acceptable as long as we get some root certificates from *somewhere*, so this will only return a hard error if no certificates were found and webpki-roots cannot be used as a fallback.