### PR TITLE
Simplify fragmented_message_opcode logic

### DIFF
--- a/src/proto/codec.rs
+++ b/src/proto/codec.rs
@@ -254,11 +254,9 @@ impl Decoder for WebSocketProtocol {
         // It is possible to receive intermediate control frames between a large other
         // frame. We therefore can't simply reset the fragmented opcode after we receive
         // a "final" frame.
-        if fin && !opcode.is_control() {
-            // Full, (possibly) chunked message received
-            self.fragmented_message_opcode = OpCode::Continuation;
-        } else if opcode != OpCode::Continuation && !opcode.is_control() {
-            // First frame of a multi-frame message
+        if (fin && opcode == OpCode::Continuation) || (!fin && opcode != OpCode::Continuation) {
+            // Full chunked message received (and opcode is Continuation)
+            // or first frame of a multi-frame message received
             self.fragmented_message_opcode = opcode;
         }
         // In all other cases, we have either a continuation or control frame, neither


### PR DESCRIPTION
Let's investigate the cases here:

`fin && !opcode.is_control()` can be simplified to `fin && opcode == OpCode::Continuation`, because `!opcode.is_control` only allows Text, Binary and Continuation. If the opcode is Text or Binary and `fin` is true, then we received a single-frame complete message and don't need to touch `fragmented_message_opcode`, so we only need to look at the Continuation case.

`opcode != OpCode::Continuation && !opcode.is_control()` is used to identify the first frame of a multi-frame message here, and is logically equivalent to `opcode == OpCode::Text || opcode == OpCode::Binary`. `!fin` implies `!opcode.is_control()` since control frames must not be fragmented and also is a better way to express the *first* frame aspect of this.

The two can then be merged into a single if case because the first case implies `opcode == OpCode::Continuation` so we can just coalesce them into one.

This improves throughput very slightly for empty, zero-length messages.