### PR TITLE
feat(server): Also return the request when accepting a connection

### DIFF
--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -19,7 +19,7 @@ async fn accept_connection(stream: TcpStream) {
 }
 
 async fn handle_connection(stream: TcpStream) -> Result<(), Error> {
-    let mut ws_stream = ServerBuilder::new()
+    let (_request, mut ws_stream) = ServerBuilder::new()
         .limits(Limits::unlimited())
         .accept(stream)
         .await?;

--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -14,7 +14,7 @@ async fn run() -> Result<(), Error> {
         let (conn, _) = listener.accept().await?;
 
         tokio::spawn(tokio::task::unconstrained(async move {
-            let mut server = unsafe {
+            let (_request, mut server) = unsafe {
                 ServerBuilder::new()
                     .config(Config::default().frame_size(usize::MAX))
                     .limits(Limits::unlimited())

--- a/examples/rustls_server.rs
+++ b/examples/rustls_server.rs
@@ -48,7 +48,7 @@ async fn main() -> io::Result<()> {
         let fut = async move {
             let stream = acceptor.accept(stream).await?;
 
-            let mut ws = tokio_websockets::ServerBuilder::new()
+            let (_request, mut ws) = tokio_websockets::ServerBuilder::new()
                 .accept(stream)
                 .await?;
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<(), Error> {
 
     loop {
         let (conn, _) = listener.accept().await?;
-        let mut server = ServerBuilder::new().accept(conn).await?;
+        let (_request, mut server) = ServerBuilder::new().accept(conn).await?;
 
         while let Some(Ok(item)) = server.next().await {
             println!("Received: {item:?}");

--- a/src/upgrade/client_request.rs
+++ b/src/upgrade/client_request.rs
@@ -140,9 +140,9 @@ impl Decoder for Codec {
             header_map.insert(name, value);
         }
 
-        builder.headers_mut().replace(&mut header_map);
-
-        let request = builder.body(()).map_err(Error::InvalidRequest)?;
+        // You have to build the request before you can assign headers: https://github.com/hyperium/http/issues/91
+        let mut request = builder.body(()).map_err(Error::InvalidRequest)?;
+        *request.headers_mut() = header_map;
 
         let ws_accept =
             ClientRequest::parse(|name| request.headers().get(name).and_then(|h| h.to_str().ok()))?

--- a/src/upgrade/client_request.rs
+++ b/src/upgrade/client_request.rs
@@ -125,6 +125,9 @@ impl Decoder for Codec {
             _ => Err(Error::Parsing(httparse::Error::Version))?,
         }
         for h in headers {
+            if h.name.is_empty() {
+                continue;
+            }
             builder = builder.header(
                 h.name,
                 http::HeaderValue::from_bytes(h.value)

--- a/src/upgrade/client_request.rs
+++ b/src/upgrade/client_request.rs
@@ -114,8 +114,8 @@ impl Decoder for Codec {
 
         let mut builder = http::request::Builder::new();
         if let Some(m) = request.method {
-            let method = http::method::Method::from_bytes(m.as_bytes())
-                .map_err(|e| Error::InvalidRequest(e.into()))?;
+            let method =
+                http::method::Method::from_bytes(m.as_bytes()).expect("httparse method is valid");
             builder = builder.method(method);
         }
 
@@ -141,7 +141,9 @@ impl Decoder for Codec {
         }
 
         // You have to build the request before you can assign headers: https://github.com/hyperium/http/issues/91
-        let mut request = builder.body(()).map_err(Error::InvalidRequest)?;
+        let mut request = builder
+            .body(())
+            .expect("httparse sees the request as valid");
         *request.headers_mut() = header_map;
 
         let ws_accept =

--- a/src/upgrade/client_request.rs
+++ b/src/upgrade/client_request.rs
@@ -127,23 +127,16 @@ impl Decoder for Codec {
         for h in headers {
             builder = builder.header(
                 h.name,
-                http::HeaderValue::from_bytes(&h.value)
+                http::HeaderValue::from_bytes(h.value)
                     .map_err(|e| Error::InvalidRequest(e.into()))?,
             );
         }
 
-        let request = builder
-            .body(())
-            .map_err(|e| Error::InvalidRequest(e.into()))?;
+        let request = builder.body(()).map_err(Error::InvalidRequest)?;
 
-        let ws_accept = ClientRequest::parse(|name| {
-            request
-                .headers()
-                .get(name)
-                .map(|h| h.to_str().ok())
-                .flatten()
-        })?
-        .ws_accept();
+        let ws_accept =
+            ClientRequest::parse(|name| request.headers().get(name).and_then(|h| h.to_str().ok()))?
+                .ws_accept();
 
         src.advance(request_len);
 

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -45,7 +45,6 @@ impl fmt::Display for Error {
             Error::ConnectionNotUpgrade => f.write_str("connection header value was not upgrade"),
             Error::UnsupportedWebSocketVersion => f.write_str("unsupported WebSocket version"),
             Error::Parsing(e) => e.fmt(f),
-            #[cfg(feature = "server")]
             Error::DidNotSwitchProtocols(status) => {
                 f.write_str("expected HTTP 101 Switching Protocols, got status code ")?;
                 f.write_fmt(format_args!("{status}"))

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -27,9 +27,6 @@ pub enum Error {
     UnsupportedWebSocketVersion,
     /// Failed to parse client request or server response.
     Parsing(httparse::Error),
-    /// Failed to convert request to a http request.
-    #[cfg(feature = "server")]
-    InvalidRequest(http::Error),
     /// Server did not return a HTTP Switching Protocols response.
     DidNotSwitchProtocols(u16),
     /// Server returned a `Sec-WebSocket-Accept` that is not compatible with the
@@ -49,7 +46,6 @@ impl fmt::Display for Error {
             Error::UnsupportedWebSocketVersion => f.write_str("unsupported WebSocket version"),
             Error::Parsing(e) => e.fmt(f),
             #[cfg(feature = "server")]
-            Error::InvalidRequest(e) => e.fmt(f),
             Error::DidNotSwitchProtocols(status) => {
                 f.write_str("expected HTTP 101 Switching Protocols, got status code ")?;
                 f.write_fmt(format_args!("{status}"))
@@ -69,8 +65,6 @@ impl std::error::Error for Error {
             | Error::DidNotSwitchProtocols(_)
             | Error::WrongWebSocketAccept => None,
             Error::Parsing(e) => Some(e),
-            #[cfg(feature = "server")]
-            Error::InvalidRequest(e) => Some(e),
         }
     }
 }

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -27,6 +27,9 @@ pub enum Error {
     UnsupportedWebSocketVersion,
     /// Failed to parse client request or server response.
     Parsing(httparse::Error),
+    /// Failed to convert request to a http request.
+    #[cfg(feature = "server")]
+    InvalidRequest(http::Error),
     /// Server did not return a HTTP Switching Protocols response.
     DidNotSwitchProtocols(u16),
     /// Server returned a `Sec-WebSocket-Accept` that is not compatible with the
@@ -45,6 +48,8 @@ impl fmt::Display for Error {
             Error::ConnectionNotUpgrade => f.write_str("connection header value was not upgrade"),
             Error::UnsupportedWebSocketVersion => f.write_str("unsupported WebSocket version"),
             Error::Parsing(e) => e.fmt(f),
+            #[cfg(feature = "server")]
+            Error::InvalidRequest(e) => e.fmt(f),
             Error::DidNotSwitchProtocols(status) => {
                 f.write_str("expected HTTP 101 Switching Protocols, got status code ")?;
                 f.write_fmt(format_args!("{status}"))
@@ -64,6 +69,7 @@ impl std::error::Error for Error {
             | Error::DidNotSwitchProtocols(_)
             | Error::WrongWebSocketAccept => None,
             Error::Parsing(e) => Some(e),
+            Error::InvalidRequest(e) => Some(e),
         }
     }
 }

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -69,6 +69,7 @@ impl std::error::Error for Error {
             | Error::DidNotSwitchProtocols(_)
             | Error::WrongWebSocketAccept => None,
             Error::Parsing(e) => Some(e),
+            #[cfg(feature = "server")]
             Error::InvalidRequest(e) => Some(e),
         }
     }

--- a/src/upgrade/server_response.rs
+++ b/src/upgrade/server_response.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use bytes::{Buf, BytesMut};
-use http::{header::HeaderName, HeaderValue, StatusCode, Version};
+use http::{header::HeaderName, HeaderValue, StatusCode};
 use httparse::{Header, Response};
 use tokio_util::codec::Decoder;
 

--- a/src/upgrade/server_response.rs
+++ b/src/upgrade/server_response.rs
@@ -79,7 +79,12 @@ impl Decoder for Codec {
         let mut parsed_response = http::Response::new(());
         *parsed_response.status_mut() =
             StatusCode::from_u16(code).map_err(|_| Error::Parsing(httparse::Error::Status))?;
-        *parsed_response.version_mut() = Version::HTTP_11;
+
+        match response.version {
+            Some(0) => *parsed_response.version_mut() = http::Version::HTTP_10,
+            Some(1) => *parsed_response.version_mut() = http::Version::HTTP_11,
+            _ => Err(Error::Parsing(httparse::Error::Version))?,
+        }
 
         let header_map = parsed_response.headers_mut();
 


### PR DESCRIPTION
This adds a way to extract the incoming request when accepting a connection.

resolves #78 