### PR TITLE
Don't send invalid closecodes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-features --all-targets
 
+      - name: Run clippy (fuzz)
+        run: cargo clippy --manifest-path fuzz/Cargo.toml --all-features --all-targets
+
   rustfmt:
     name: Format
     runs-on: ubuntu-latest
@@ -133,6 +136,9 @@ jobs:
 
       - name: Run cargo fmt
         run: cargo fmt -- --check
+
+      - name: Run cargo fmt (fuzzer)
+        run: cargo fmt --manifest-path fuzz/Cargo.toml -- --check
 
   min-vers:
     name: Minimal crate versions

--- a/fuzz/fuzz_targets/stream.rs
+++ b/fuzz/fuzz_targets/stream.rs
@@ -50,7 +50,7 @@ impl From<ArbitraryMessage> for Message {
                 Message::close(
                     CloseCode::try_from(code)
                         .ok()
-                        .filter(|code| code.is_sendable()),
+                        .filter(|code| !code.is_reserved()),
                     &reason,
                 )
             }

--- a/src/proto/codec.rs
+++ b/src/proto/codec.rs
@@ -245,7 +245,7 @@ impl Decoder for WebSocketProtocol {
                         .try_into()
                         .unwrap_unchecked()
                 }))?;
-                if !code.is_sendable() {
+                if code.is_reserved() {
                     return Err(Error::Protocol(ProtocolError::InvalidCloseCode));
                 }
 

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -394,8 +394,8 @@ impl Message {
     ///
     /// # Panics
     /// - If the `code` is reserved so it cannot be sent.
-    /// - If `code` is present and the `reason` exceeds 123 bytes,
-    ///   the protocol-imposed limit.
+    /// - If `code` is present and the `reason` exceeds 123 bytes, the
+    ///   protocol-imposed limit.
     #[must_use]
     #[track_caller]
     pub fn close(code: Option<CloseCode>, reason: &str) -> Self {

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -116,7 +116,7 @@ impl CloseCode {
 
 impl CloseCode {
     /// Whether the close code is allowed to be sent over the wire.
-    pub(super) fn is_sendable(self) -> bool {
+    pub fn is_sendable(self) -> bool {
         match self.0.get() {
             1004 | 1005 | 1006 | 1015 => false,
             1000..=4999 => true,
@@ -400,6 +400,7 @@ impl Message {
         let mut payload = BytesMut::with_capacity((2 + reason.len()) * usize::from(code.is_some()));
 
         if let Some(code) = code {
+            assert!(code.is_sendable());
             payload.put_u16(code.into());
 
             assert!(reason.len() <= 123);

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -116,6 +116,7 @@ impl CloseCode {
 
 impl CloseCode {
     /// Whether the close code is allowed to be sent over the wire.
+    #[must_use]
     pub fn is_sendable(self) -> bool {
         match self.0.get() {
             1004 | 1005 | 1006 | 1015 => false,

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -395,7 +395,7 @@ impl Message {
     /// # Panics
     /// - If the `code` is reserved so it cannot be sent.
     /// - If `code` is present and the `reason` exceeds 123 bytes,
-    /// the protocol-imposed limit.
+    ///   the protocol-imposed limit.
     #[must_use]
     #[track_caller]
     pub fn close(code: Option<CloseCode>, reason: &str) -> Self {


### PR DESCRIPTION
- [x] `Message::close` panics on un-sendable `CloseCode`.
- [x] Add `CloseCode::is_reserved`
- [x] Fuzzer doesn't send un-sendable `CloseCode`.
- [x] `cargo fmt`.
- [x] CI check/fmt fuzzer.