### PR TITLE
More SIMD optimizations

### DIFF
--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -25,15 +25,9 @@ jobs:
           mkdir autobahn/reports
           echo "<!DOCTYPE html><html><head><title>Autobahn test suite results</title></head><body><a href="clients/index.html">Clients</a><br><a href="servers/index.html">Servers</a></body></html>" > autobahn/reports/index.html
 
-      - name: Build tokio-websockets (SIMD)
+      - name: Build tokio-websockets
         run: |
-          cargo build --release --example autobahn_client --example autobahn_server --features client,fastrand,nightly,server,sha1_smol,simd
-          mv target/x86_64-unknown-linux-gnu/release/examples/autobahn_client target/x86_64-unknown-linux-gnu/release/examples/autobahn_client_simd
-          mv target/x86_64-unknown-linux-gnu/release/examples/autobahn_server target/x86_64-unknown-linux-gnu/release/examples/autobahn_server_simd
-
-      - name: Build tokio-websockets (no SIMD)
-        run: |
-          cargo build --release --example autobahn_client --example autobahn_server --features client,fastrand,server,sha1_smol
+          cargo build --release --example autobahn_client --example autobahn_server --features client,fastrand,nightly,server,sha1_smol
 
       - name: Run testsuite
         run: |

--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -35,13 +35,6 @@ jobs:
         run: |
           cargo build --release --example autobahn_client --example autobahn_server --features client,fastrand,server,sha1_smol
 
-      - name: Build tokio-tungstenite
-        run: |
-          git clone https://github.com/snapview/tokio-tungstenite.git
-          cd tokio-tungstenite
-          cargo build --release --examples
-          cd ..
-
       - name: Run testsuite
         run: |
           ./scripts/autobahn_client_ci.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ rustls-native-roots = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:rustls-n
 rustls-platform-verifier = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:rustls-platform-verifier"]
 rustls-bring-your-own-connector = ["dep:rustls-pki-types", "dep:tokio-rustls"]
 rustls-tls12 = ["tokio-rustls?/tls12"]
+simd = [] # No effect, deprecated
 nightly = ["simdutf8/aarch64_neon_prefetch"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ license = "MIT"
 bytes = "1.7"
 futures-core = "0.3"
 futures-sink = "0.3"
+# We enable aarch64_neon feature because it is MSRV-gated but ours is higher than 1.59
+simdutf8 = { version = "0.1", default-features = false, features = ["std", "aarch64_neon"] }
+
 tokio = "1"
 # tokio-util 0.7.3 is the first to depend on tracing without default features, otherwise minvers break
 tokio-util = { version = "0.7.3", features = ["codec", "io"] }
@@ -27,9 +30,6 @@ getrandom = { version = "0.2", default-features = false, optional = true }
 rand = { version = "0.8", default-features = false, features = ["std", "std_rng"], optional = true }
 
 # SIMD
-# We enable aarch64_neon feature because it is MSRV-gated but ours is higher than 1.59
-simdutf8 = { version = "0.1", default-features = false, features = ["std", "aarch64_neon"], optional = true }
-
 # Client
 base64 = { version = "0.22", optional = true }
 http = { version = "1", default-features = false, features = ["std"], optional = true }
@@ -57,14 +57,13 @@ aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
 fips = ["aws_lc_rs", "aws-lc-rs?/fips", "tokio-rustls?/fips"]
 ring = ["dep:ring", "tokio-rustls?/ring"]
 server = ["dep:base64", "dep:http", "dep:httparse", "tokio/io-util"]
-simd = ["dep:simdutf8"]
 native-tls = ["dep:tokio-native-tls"]
 rustls-webpki-roots = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:webpki-roots"]
 rustls-native-roots = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:rustls-native-certs"]
 rustls-platform-verifier = ["dep:rustls-pki-types", "dep:tokio-rustls", "dep:rustls-platform-verifier"]
 rustls-bring-your-own-connector = ["dep:rustls-pki-types", "dep:tokio-rustls"]
 rustls-tls12 = ["tokio-rustls?/tls12"]
-nightly = ["simdutf8?/aarch64_neon_prefetch"]
+nightly = ["simdutf8/aarch64_neon_prefetch"]
 
 [dev-dependencies]
 futures-util = { version = "0.3.14", default-features = false, features = ["sink"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,9 +114,13 @@ required-features = ["server"]
 features = ["client", "aws_lc_rs", "ring", "fastrand", "getrandom", "rand", "server", "simd", "native-tls", "rustls-native-roots", "rustls-webpki-roots", "rustls-platform-verifier", "rustls-tls12", "nightly"]
 rustdoc-args = ["--cfg", "docsrs"]
 
+[profile.dev]
+panic = "abort"
+
 [profile.release]
 codegen-units = 1
 debug = false
 incremental = false
 lto = true
 opt-level = 3
+panic = "abort"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ High performance, strict, tokio-util based WebSockets implementation.
 
 Feature flags in tokio-websockets are added to allow tailoring it to your needs.
 
+- The `simd` feature flag is deprecated and has no effect. SIMD support is detected at runtime now rather than opting in at compile time
 - The `nightly` feature when using a nightly compiler will enable AVX512, NEON (on 32-bit ARM) or AltiVec accelerated masking
 - `client` enables a tiny client implementation
 - `server` enables a tiny server implementation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ High performance, strict, tokio-util based WebSockets implementation.
 
 - Built with tokio-util, intended to be used with tokio from the ground up
 - Minimal dependencies: The base only requires:
-  - `tokio`, `tokio-util`, `bytes`, `futures-core`, `futures-sink`
+  - `tokio`, `tokio-util`, `bytes`, `futures-core`, `futures-sink`, `simdutf8`
   - SHA1 backend, e.g. `sha1_smol` (see [Feature flags](#feature-flags))
 - Big selection of features to tailor dependencies to any project (see [Feature flags](#feature-flags))
 - SIMD support: AVX512, AVX2, SSE2, NEON or AltiVec for frame (un)masking and accelerated UTF-8 validation
@@ -25,7 +25,7 @@ High performance, strict, tokio-util based WebSockets implementation.
 
 Feature flags in tokio-websockets are added to allow tailoring it to your needs.
 
-- `simd` will enable AVX2, SSE2 or NEON (on aarch64) accelerated masking and UTF-8 validation. Additionally enabling the `nightly` feature when using a nightly compiler will also enable AVX512, NEON (on 32-bit ARM) or AltiVec accelerated masking
+- The `nightly` feature when using a nightly compiler will enable AVX512, NEON (on 32-bit ARM) or AltiVec accelerated masking
 - `client` enables a tiny client implementation
 - `server` enables a tiny server implementation
 

--- a/autobahn/config/fuzzingclient.json
+++ b/autobahn/config/fuzzingclient.json
@@ -4,10 +4,6 @@
         {
             "agent": "tokio-websockets",
             "url": "ws://127.0.0.1:9006"
-        },
-        {
-            "agent": "tokio-websockets-simd",
-            "url": "ws://127.0.0.1:9004"
         }
     ],
     "cases": ["*"],

--- a/autobahn/config/fuzzingclient.json
+++ b/autobahn/config/fuzzingclient.json
@@ -8,10 +8,6 @@
         {
             "agent": "tokio-websockets-simd",
             "url": "ws://127.0.0.1:9004"
-        },
-        {
-            "agent": "tokio-tungstenite",
-            "url": "ws://127.0.0.1:9002"
         }
     ],
     "cases": ["*"],

--- a/autobahn/validate.py
+++ b/autobahn/validate.py
@@ -6,10 +6,7 @@ CLIENTS = os.sep.join([AUTOBAHN_DIR, "reports", "clients", "index.json"])
 SERVERS = os.sep.join([AUTOBAHN_DIR, "reports", "servers", "index.json"])
 
 def validate_report_json(json):
-    for (client, cases) in json.items():
-        if "tokio-websockets" not in client:
-            continue # We do not care about other libraries' results
-
+    for (_client, cases) in json.items():
         allowed_behavior = ("OK", "INFORMATIONAL", "UNIMPLEMENTED")
 
         for (report, result) in cases.items():

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -4,20 +4,6 @@ use futures_util::{SinkExt, StreamExt};
 use http::Uri;
 use tokio_websockets::{ClientBuilder, Connector, Error, Limits};
 
-#[cfg(feature = "simd")]
-macro_rules! agent {
-    () => {
-        "tokio-websockets-simd"
-    };
-}
-
-#[cfg(not(feature = "simd"))]
-macro_rules! agent {
-    () => {
-        "tokio-websockets"
-    };
-}
-
 async fn get_case_count() -> Result<u32, Error> {
     let uri = Uri::from_static("ws://localhost:9001/getCaseCount");
     let (mut stream, _) = ClientBuilder::from_uri(uri)
@@ -32,8 +18,7 @@ async fn get_case_count() -> Result<u32, Error> {
 }
 
 async fn update_reports() -> Result<(), Error> {
-    let uri_str = concat!("ws://localhost:9001/updateReports?agent=", agent!());
-    let uri = Uri::from_static(uri_str);
+    let uri = Uri::from_static("ws://localhost:9001/updateReports?agent=tokio-websockets");
     let (mut stream, _) = ClientBuilder::from_uri(uri)
         .connector(&Connector::Plain)
         .connect()
@@ -48,9 +33,8 @@ async fn run_test(case: u32) -> Result<(), Error> {
     println!("Running test case {case}");
 
     let uri = Uri::from_str(&format!(
-        "ws://localhost:9001/runCase?case={}&agent={}",
+        "ws://localhost:9001/runCase?case={}&agent=tokio-websockets",
         case,
-        agent!()
     ))
     .unwrap();
 

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -4,11 +4,6 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_websockets::{Error, Limits, ServerBuilder};
 
-#[cfg(feature = "simd")]
-const PORT: u16 = 9004;
-#[cfg(not(feature = "simd"))]
-const PORT: u16 = 9006;
-
 async fn accept_connection(stream: TcpStream) {
     if let Err(e) = handle_connection(stream).await {
         match e {
@@ -37,7 +32,7 @@ async fn handle_connection(stream: TcpStream) -> Result<(), Error> {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let addr: SocketAddr = ([127, 0, 0, 1], PORT).into();
+    let addr: SocketAddr = ([127, 0, 0, 1], 9006).into();
     let listener = TcpListener::bind(&addr).await.expect("Can't listen");
 
     println!("Listening on: {addr}");

--- a/scripts/autobahn_client_ci.sh
+++ b/scripts/autobahn_client_ci.sh
@@ -19,4 +19,3 @@ podman run -d --rm \
 sleep 3
 
 target/x86_64-unknown-linux-gnu/release/examples/autobahn_client
-target/x86_64-unknown-linux-gnu/release/examples/autobahn_client_simd

--- a/scripts/autobahn_client_ci.sh
+++ b/scripts/autobahn_client_ci.sh
@@ -20,4 +20,3 @@ sleep 3
 
 target/x86_64-unknown-linux-gnu/release/examples/autobahn_client
 target/x86_64-unknown-linux-gnu/release/examples/autobahn_client_simd
-tokio-tungstenite/target/x86_64-unknown-linux-gnu/release/examples/autobahn-client

--- a/scripts/autobahn_server_ci.sh
+++ b/scripts/autobahn_server_ci.sh
@@ -5,14 +5,12 @@ set -x
 function cleanup() {
     kill -9 ${WSSERVER1_PID} || true
     kill -9 ${WSSERVER2_PID} || true
-    kill -9 ${WSSERVER3_PID} || true
 }
 
 trap cleanup TERM EXIT
 
 target/x86_64-unknown-linux-gnu/release/examples/autobahn_server & WSSERVER1_PID=$!
 target/x86_64-unknown-linux-gnu/release/examples/autobahn_server_simd & WSSERVER2_PID=$!
-tokio-tungstenite/target/x86_64-unknown-linux-gnu/release/examples/autobahn-server & WSSERVER3_PID=$!
 
 sleep 3
 

--- a/scripts/autobahn_server_ci.sh
+++ b/scripts/autobahn_server_ci.sh
@@ -3,14 +3,12 @@ set -euo pipefail
 set -x
 
 function cleanup() {
-    kill -9 ${WSSERVER1_PID} || true
-    kill -9 ${WSSERVER2_PID} || true
+    kill -9 ${WSSERVER_PID} || true
 }
 
 trap cleanup TERM EXIT
 
-target/x86_64-unknown-linux-gnu/release/examples/autobahn_server & WSSERVER1_PID=$!
-target/x86_64-unknown-linux-gnu/release/examples/autobahn_server_simd & WSSERVER2_PID=$!
+target/x86_64-unknown-linux-gnu/release/examples/autobahn_server & WSSERVER_PID=$!
 
 sleep 3
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,16 @@
 // Required for AVX512 until stable
 #![cfg_attr(
     all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")),
-    feature(stdarch_x86_avx512)
+    feature(stdarch_x86_avx512, avx512_target_feature)
 )]
 // Required for NEON on 32-bit ARM until stable
 #![cfg_attr(
     all(feature = "nightly", target_arch = "arm"),
-    feature(stdarch_arm_neon_intrinsics)
+    feature(
+        stdarch_arm_neon_intrinsics,
+        stdarch_arm_feature_detection,
+        arm_target_feature
+    )
 )]
 // Required for VSX until stable
 #![cfg_attr(
@@ -22,7 +26,11 @@
         feature = "nightly",
         any(target_arch = "powerpc64", target_arch = "powerpc")
     ),
-    feature(stdarch_powerpc)
+    feature(
+        stdarch_powerpc,
+        stdarch_powerpc_feature_detection,
+        powerpc_target_feature
+    )
 )]
 #![doc = include_str!("../README.md")]
 

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -1,5 +1,5 @@
-//! This module contains three implementations of WebSocket frame masking and
-//! unmasking, both ways use the same algorithm and methods:
+//! This module contains six implementations of WebSocket frame masking and
+//! unmasking, all of them using the same algorithm and methods:
 //!   - One AVX512-based implementation that masks 64 bytes per cycle (requires
 //!     nightly rust)
 //!   - One AVX2-based implementation that masks 32 bytes per cycle
@@ -8,275 +8,218 @@
 //!     nightly rust on 32-bit ARM)
 //!   - One AltiVec-based implementation that masks 16 bytes per cycle (requires
 //!     nightly rust)
-//!   - A fallback implementation without SIMD
+//!   - A fallback implementation that masks 8 bytes per cycle
 //!
-//! The SIMD implementations will only be used if the `simd` feature is active.
+//! The SIMD implementations will be used if CPU support for them is detected at
+//! runtime or enabled at compile time via compiler flags.
 
-/// Websocket frame masking implementation using AVX512.
-#[cfg(all(feature = "simd", feature = "nightly", target_feature = "avx512f"))]
-mod imp {
+/// (Un-)masks input bytes with the framing key using AVX512.
+///
+/// The input bytes may be further in the payload and therefore the offset
+/// into the payload must be specified.
+///
+/// This will use a fallback implementation for less than 64 bytes. For
+/// sufficiently large inputs, it masks in chunks of 64 bytes per
+/// instruction, applying the fallback method on all remaining data.
+#[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
+#[target_feature(enable = "avx512f")]
+unsafe fn frame_avx512(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{__m512i, _mm512_set1_epi32, _mm512_xor_si512};
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::{__m512i, _mm512_set1_epi32, _mm512_xor_si512};
 
-    /// (Un-)masks input bytes with the framing key using AVX512.
-    ///
-    /// The input bytes may be further in the payload and therefore the offset
-    /// into the payload must be specified.
-    ///
-    /// This will use a fallback implementation for less than 64 bytes. For
-    /// sufficiently large inputs, it masks in chunks of 64 bytes per
-    /// instruction, applying the fallback method on all remaining data.
-    pub fn frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
-        unsafe {
-            let (prefix, aligned_data, suffix) = input.align_to_mut::<__m512i>();
+    unsafe {
+        let (prefix, aligned_data, suffix) = input.align_to_mut::<__m512i>();
 
-            // Run fallback implementation on unaligned prefix data
-            super::fallback_frame(key, prefix, offset);
-            offset = (offset + prefix.len()) % key.len();
+        // Run fallback implementation on unaligned prefix data
+        fallback_frame(key, prefix, offset);
+        offset = (offset + prefix.len()) % key.len();
 
-            if !aligned_data.is_empty() {
-                #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-                let mask = _mm512_set1_epi32(
-                    i32::from_be_bytes(key)
-                        .rotate_left(offset as u32 * u8::BITS)
-                        .to_be(),
-                );
+        if !aligned_data.is_empty() {
+            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
+            let mask = _mm512_set1_epi32(
+                i32::from_be_bytes(key)
+                    .rotate_left(offset as u32 * u8::BITS)
+                    .to_be(),
+            );
 
-                for block in aligned_data {
-                    *block = _mm512_xor_si512(*block, mask);
-                }
+            for block in aligned_data {
+                *block = _mm512_xor_si512(*block, mask);
             }
-
-            // Run fallback implementation on unaligned suffix data
-            super::fallback_frame(key, suffix, offset);
         }
+
+        // Run fallback implementation on unaligned suffix data
+        fallback_frame(key, suffix, offset);
     }
 }
 
-/// Websocket frame masking implementation using AVX2.
-#[cfg(all(
-    feature = "simd",
-    not(all(feature = "nightly", target_feature = "avx512f")),
-    target_feature = "avx2"
-))]
-mod imp {
+/// (Un-)masks input bytes with the framing key using AVX2.
+///
+/// The input bytes may be further in the payload and therefore the offset
+/// into the payload must be specified.
+///
+/// This will use a fallback implementation for less than 32 bytes. For
+/// sufficiently large inputs, it masks in chunks of 32 bytes per
+/// instruction, applying the fallback method on all remaining data.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn frame_avx2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{__m256i, _mm256_set1_epi32, _mm256_xor_si256};
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::{__m256i, _mm256_set1_epi32, _mm256_xor_si256};
 
-    /// (Un-)masks input bytes with the framing key using AVX2.
-    ///
-    /// The input bytes may be further in the payload and therefore the offset
-    /// into the payload must be specified.
-    ///
-    /// This will use a fallback implementation for less than 32 bytes. For
-    /// sufficiently large inputs, it masks in chunks of 32 bytes per
-    /// instruction, applying the fallback method on all remaining data.
-    pub fn frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
-        unsafe {
-            let (prefix, aligned_data, suffix) = input.align_to_mut::<__m256i>();
+    unsafe {
+        let (prefix, aligned_data, suffix) = input.align_to_mut::<__m256i>();
 
-            // Run fallback implementation on unaligned prefix data
-            super::fallback_frame(key, prefix, offset);
-            offset = (offset + prefix.len()) % key.len();
+        // Run fallback implementation on unaligned prefix data
+        fallback_frame(key, prefix, offset);
+        offset = (offset + prefix.len()) % key.len();
 
-            if !aligned_data.is_empty() {
-                #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-                let mask = _mm256_set1_epi32(
-                    i32::from_be_bytes(key)
-                        .rotate_left(offset as u32 * u8::BITS)
-                        .to_be(),
-                );
+        if !aligned_data.is_empty() {
+            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
+            let mask = _mm256_set1_epi32(
+                i32::from_be_bytes(key)
+                    .rotate_left(offset as u32 * u8::BITS)
+                    .to_be(),
+            );
 
-                for block in aligned_data {
-                    *block = _mm256_xor_si256(*block, mask);
-                }
+            for block in aligned_data {
+                *block = _mm256_xor_si256(*block, mask);
             }
-
-            // Run fallback implementation on unaligned suffix data
-            super::fallback_frame(key, suffix, offset);
         }
+
+        // Run fallback implementation on unaligned suffix data
+        fallback_frame(key, suffix, offset);
     }
 }
 
-/// Websocket frame masking implementation using SSE2.
-#[cfg(all(
-    feature = "simd",
-    not(all(feature = "nightly", target_feature = "avx512f")),
-    not(target_feature = "avx2"),
-    target_feature = "sse2"
-))]
-mod imp {
+/// (Un-)masks input bytes with the framing key using SSE2.
+///
+/// The input bytes may be further in the payload and therefore the offset
+/// into the payload must be specified.
+///
+/// This will use a fallback implementation for less than 16 bytes. For
+/// sufficiently large inputs, it masks in chunks of 16 bytes per
+/// instruction, applying the fallback method on all remaining data.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "sse2")]
+unsafe fn frame_sse2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{__m128i, _mm_set1_epi32, _mm_xor_si128};
     #[cfg(target_arch = "x86_64")]
     use std::arch::x86_64::{__m128i, _mm_set1_epi32, _mm_xor_si128};
 
-    /// (Un-)masks input bytes with the framing key using SSE2.
-    ///
-    /// The input bytes may be further in the payload and therefore the offset
-    /// into the payload must be specified.
-    ///
-    /// This will use a fallback implementation for less than 16 bytes. For
-    /// sufficiently large inputs, it masks in chunks of 16 bytes per
-    /// instruction, applying the fallback method on all remaining data.
-    pub fn frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
-        unsafe {
-            let (prefix, aligned_data, suffix) = input.align_to_mut::<__m128i>();
+    unsafe {
+        let (prefix, aligned_data, suffix) = input.align_to_mut::<__m128i>();
 
-            // Run fallback implementation on unaligned prefix data
-            super::fallback_frame(key, prefix, offset);
-            offset = (offset + prefix.len()) % key.len();
+        // Run fallback implementation on unaligned prefix data
+        fallback_frame(key, prefix, offset);
+        offset = (offset + prefix.len()) % key.len();
 
-            if !aligned_data.is_empty() {
-                #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-                let mask = _mm_set1_epi32(
-                    i32::from_be_bytes(key)
-                        .rotate_left(offset as u32 * u8::BITS)
-                        .to_be(),
-                );
+        if !aligned_data.is_empty() {
+            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
+            let mask = _mm_set1_epi32(
+                i32::from_be_bytes(key)
+                    .rotate_left(offset as u32 * u8::BITS)
+                    .to_be(),
+            );
 
-                for block in aligned_data {
-                    *block = _mm_xor_si128(*block, mask);
-                }
+            for block in aligned_data {
+                *block = _mm_xor_si128(*block, mask);
             }
-
-            // Run fallback implementation on unaligned suffix data
-            super::fallback_frame(key, suffix, offset);
         }
+
+        // Run fallback implementation on unaligned suffix data
+        fallback_frame(key, suffix, offset);
     }
 }
 
-/// Websocket frame masking implementation using NEON.
-#[cfg(all(
-    feature = "simd",
-    target_feature = "neon",
-    any(target_arch = "aarch64", all(target_arch = "arm", feature = "nightly"))
-))]
-mod imp {
+/// (Un-)masks input bytes with the framing key using NEON.
+///
+/// The input bytes may be further in the payload and therefore the offset
+/// into the payload must be specified.
+///
+/// This will use a fallback implementation for less than 16 bytes. For
+/// sufficiently large inputs, it masks in chunks of 16 bytes per
+/// instruction, applying the fallback method on all remaining data.
+#[cfg(any(all(feature = "nightly", target_arch = "arm"), target_arch = "aarch64"))]
+#[target_feature(enable = "neon")]
+unsafe fn frame_neon(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     #[cfg(target_arch = "aarch64")]
     use std::arch::aarch64::{uint8x16_t, veorq_u8, vld1q_dup_s32, vreinterpretq_u8_s32};
     #[cfg(target_arch = "arm")]
     use std::arch::arm::{uint8x16_t, veorq_u8, vld1q_dup_s32, vreinterpretq_u8_s32};
 
-    /// (Un-)masks input bytes with the framing key using NEON.
-    ///
-    /// The input bytes may be further in the payload and therefore the offset
-    /// into the payload must be specified.
-    ///
-    /// This will use a fallback implementation for less than 16 bytes. For
-    /// sufficiently large inputs, it masks in chunks of 16 bytes per
-    /// instruction, applying the fallback method on all remaining data.
-    pub fn frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
-        unsafe {
-            let (prefix, aligned_data, suffix) = input.align_to_mut::<uint8x16_t>();
+    unsafe {
+        let (prefix, aligned_data, suffix) = input.align_to_mut::<uint8x16_t>();
 
-            // Run fallback implementation on unaligned prefix data
-            super::fallback_frame(key, prefix, offset);
-            offset = (offset + prefix.len()) % key.len();
+        // Run fallback implementation on unaligned prefix data
+        fallback_frame(key, prefix, offset);
+        offset = (offset + prefix.len()) % key.len();
 
-            if !aligned_data.is_empty() {
-                #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-                let mask = vreinterpretq_u8_s32(vld1q_dup_s32(
-                    &i32::from_be_bytes(key)
-                        .rotate_left(offset as u32 * u8::BITS)
-                        .to_be() as *const i32,
-                ));
+        if !aligned_data.is_empty() {
+            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
+            let mask = vreinterpretq_u8_s32(vld1q_dup_s32(
+                &i32::from_be_bytes(key)
+                    .rotate_left(offset as u32 * u8::BITS)
+                    .to_be() as *const i32,
+            ));
 
-                for block in aligned_data {
-                    *block = veorq_u8(*block, mask);
-                }
+            for block in aligned_data {
+                *block = veorq_u8(*block, mask);
             }
-
-            // Run fallback implementation on unaligned suffix data
-            super::fallback_frame(key, suffix, offset);
         }
+
+        // Run fallback implementation on unaligned suffix data
+        fallback_frame(key, suffix, offset);
     }
 }
 
-/// Websocket frame masking implementation using AltiVec.
-#[cfg(all(feature = "simd", feature = "nightly", target_feature = "altivec"))]
-mod imp {
+/// (Un-)masks input bytes with the framing key using AltiVec.
+///
+/// The input bytes may be further in the payload and therefore the offset
+/// into the payload must be specified.
+///
+/// This will use a fallback implementation for less than 16 bytes. For
+/// sufficiently large inputs, it masks in chunks of 16 bytes per
+/// instruction, applying the fallback method on all remaining data.
+#[cfg(all(
+    feature = "nightly",
+    any(target_arch = "powerpc", target_arch = "powerpc64")
+))]
+#[target_feature(enable = "altivec")]
+unsafe fn frame_altivec(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     #[cfg(target_arch = "powerpc")]
     use std::arch::powerpc::{vec_splats, vec_xor, vector_unsigned_char};
     #[cfg(target_arch = "powerpc64")]
     use std::arch::powerpc64::{vec_splats, vec_xor, vector_unsigned_char};
     use std::mem::transmute;
 
-    /// (Un-)masks input bytes with the framing key using AltiVec.
-    ///
-    /// The input bytes may be further in the payload and therefore the offset
-    /// into the payload must be specified.
-    ///
-    /// This will use a fallback implementation for less than 16 bytes. For
-    /// sufficiently large inputs, it masks in chunks of 16 bytes per
-    /// instruction, applying the fallback method on all remaining data.
-    pub fn frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
-        unsafe {
-            let (prefix, aligned_data, suffix) = input.align_to_mut::<vector_unsigned_char>();
+    unsafe {
+        let (prefix, aligned_data, suffix) = input.align_to_mut::<vector_unsigned_char>();
 
-            // Run fallback implementation on unaligned prefix data
-            super::fallback_frame(key, prefix, offset);
-            offset = (offset + prefix.len()) % key.len();
+        // Run fallback implementation on unaligned prefix data
+        fallback_frame(key, prefix, offset);
+        offset = (offset + prefix.len()) % key.len();
 
-            if !aligned_data.is_empty() {
-                // SAFETY: 4x i32 to 16x u8 is safe
-                #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-                let mask: vector_unsigned_char = transmute(vec_splats(
-                    i32::from_be_bytes(key)
-                        .rotate_left(offset as u32 * u8::BITS)
-                        .to_be(),
-                ));
+        if !aligned_data.is_empty() {
+            // SAFETY: 4x i32 to 16x u8 is safe
+            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
+            let mask: vector_unsigned_char = transmute(vec_splats(
+                i32::from_be_bytes(key)
+                    .rotate_left(offset as u32 * u8::BITS)
+                    .to_be(),
+            ));
 
-                for block in aligned_data {
-                    *block = vec_xor(*block, mask);
-                }
+            for block in aligned_data {
+                *block = vec_xor(*block, mask);
             }
-
-            // Run fallback implementation on unaligned suffix data
-            super::fallback_frame(key, suffix, offset);
         }
-    }
-}
 
-/// Websocket frame masking fallback implementation.
-#[cfg(any(
-    not(feature = "simd"),
-    all(
-        feature = "simd",
-        any(
-            all(target_arch = "aarch64", not(target_feature = "neon")),
-            all(
-                target_arch = "arm",
-                not(all(target_feature = "neon", feature = "nightly"))
-            )
-        )
-    ),
-    all(
-        feature = "simd",
-        any(target_arch = "powerpc64", target_arch = "powerpc"),
-        any(not(target_feature = "altivec"), not(feature = "nightly"))
-    ),
-    not(any(
-        target_arch = "x86_64",
-        target_arch = "x86",
-        target_arch = "aarch64",
-        target_arch = "arm",
-        target_arch = "powerpc64",
-        target_arch = "powerpc"
-    ))
-))]
-mod imp {
-    /// (Un-)masks input bytes with the framing key.
-    ///
-    /// The input bytes may be further in the payload and therefore the offset
-    /// into the payload must be specified.
-    #[inline]
-    pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
-        super::fallback_frame(key, input, offset);
+        // Run fallback implementation on unaligned suffix data
+        fallback_frame(key, suffix, offset);
     }
 }
 
@@ -330,7 +273,66 @@ fn fallback_frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     one_byte_at_once(key, suffix, offset);
 }
 
-pub use imp::frame;
+/// (Un-)masks input bytes with the framing key.
+///
+/// The input bytes may be further in the payload and therefore the offset
+/// into the payload must be specified.
+#[inline]
+pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        use std::arch::is_x86_feature_detected;
+
+        #[cfg(feature = "nightly")]
+        if is_x86_feature_detected!("avx512f") {
+            return unsafe { frame_avx512(key, input, offset) };
+        }
+
+        if is_x86_feature_detected!("avx2") {
+            return unsafe { frame_avx2(key, input, offset) };
+        } else if is_x86_feature_detected!("sse2") {
+            return unsafe { frame_sse2(key, input, offset) };
+        }
+    }
+
+    #[cfg(all(feature = "nightly", target_arch = "arm"))]
+    {
+        use std::arch::is_arm_feature_detected;
+
+        if is_arm_feature_detected!("neon") {
+            return unsafe { frame_neon(key, input, offset) };
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        use std::arch::is_aarch64_feature_detected;
+
+        if is_aarch64_feature_detected!("neon") {
+            return unsafe { frame_neon(key, input, offset) };
+        }
+    }
+
+    #[cfg(all(feature = "nightly", target_arch = "powerpc"))]
+    {
+        use std::arch::is_powerpc_feature_detected;
+
+        if is_powerpc_feature_detected!("altivec") {
+            return unsafe { frame_altivec(key, input, offset) };
+        }
+    }
+
+    #[cfg(all(feature = "nightly", target_arch = "powerpc64"))]
+    {
+        use std::arch::is_powerpc64_feature_detected;
+
+        if is_powerpc64_feature_detected!("altivec") {
+            return unsafe { frame_altivec(key, input, offset) };
+        }
+    }
+
+    fallback_frame(key, input, offset);
+}
 
 #[cfg(all(test, feature = "client", feature = "fastrand"))]
 #[test]

--- a/tests/client_is_send.rs
+++ b/tests/client_is_send.rs
@@ -1,3 +1,4 @@
+#![cfg(all(feature = "client", feature = "server"))]
 use tokio::net::TcpListener;
 use tokio_websockets::{ClientBuilder, ServerBuilder};
 


### PR DESCRIPTION
In the SIMD implementations, we convert the `[u8; 4]` to an `i32` anyways, so we can choose between rotating the array or the integer. Rotating the array isn't optimized well by rustc/LLVM as seen in `cargo asm`. On x86, rotating the integer is condensed into just a single instruction, `rol`. We need to load the integer as big-endian to make the rotation possible and then swap byteorder on little-endian targets, which is very efficient on most architectures, e.g. x86 using `bswap`.

<details>
<summary>Full diff of `cargo-asm`:</summary>

```diff
diff --git a/tmp/old.txt b/tmp/new.txt
index 6fd3e7b86..84072182c 100644
--- a/tmp/old.txt
+++ b/tmp/new.txt
@@ -2,19 +2,7 @@
 	.p2align	4, 0x90
 .type	tokio_websockets::mask::imp::frame,@function
 tokio_websockets::mask::imp::frame:
-		// /home/jens/tokio-websockets/src/mask.rs : 120
-		pub fn frame(mut key: [u8; 4], input: &mut [u8], mut offset: usize) {
 	.cfi_startproc
-	push rbp
-	.cfi_def_cfa_offset 16
-	push r14
-	.cfi_def_cfa_offset 24
-	push rbx
-	.cfi_def_cfa_offset 32
-	.cfi_offset rbx, -32
-	.cfi_offset r14, -24
-	.cfi_offset rbp, -16
-	mov dword ptr [rsp - 12], edi
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1952
 		let aligned_address = wrapping_add(addr, a_minus_one) & wrapping_sub(0, a);
 	lea r11, [rsi + 15]
@@ -27,10 +15,13 @@ tokio_websockets::mask::imp::frame:
 	mov rax, rdx
 	sub rax, r11
 	jae .LBB5_2
-	xor r9d, r9d
 	mov eax, 1
-	mov r10d, 16
+	mov r9d, 16
+	xor r10d, r10d
 	xor r8d, r8d
+	push rbx
+	.cfi_def_cfa_offset 16
+	.cfi_offset rbx, -16
 	mov dword ptr [rsp - 8], edi
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs : 1584
 		self.as_ptr() == other.as_ptr()
@@ -40,13 +31,15 @@ tokio_websockets::mask::imp::frame:
 	jne .LBB5_4
 	jmp .LBB5_6
 .LBB5_2:
+	.cfi_def_cfa_offset 8
+	.cfi_restore rbx
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mut_ptr.rs : 1057
 		unsafe { intrinsics::offset(self, count) }
-	lea r10, [rsi + r11]
+	lea r9, [rsi + r11]
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/mod.rs : 3873
 		let us_len = self.len() / ts * us;
-	mov r9, rax
-	shr r9, 4
+	mov r10, rax
+	shr r10, 4
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/mod.rs : 3875
 		let ts_len = self.len() % ts;
 	mov r8d, eax
@@ -56,8 +49,11 @@ tokio_websockets::mask::imp::frame:
 	and rax, -16
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mut_ptr.rs : 1057
 		unsafe { intrinsics::offset(self, count) }
-	add rax, r10
+	add rax, r9
 	mov rdx, r11
+	push rbx
+	.cfi_def_cfa_offset 16
+	.cfi_offset rbx, -16
 	mov dword ptr [rsp - 8], edi
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs : 1584
 		self.as_ptr() == other.as_ptr()
@@ -69,7 +65,7 @@ tokio_websockets::mask::imp::frame:
 	xor r11d, r11d
 	.p2align	4, 0x90
 .LBB5_5:
-		// /home/jens/tokio-websockets/src/mask.rs : 278
+		// /home/jens/tokio-websockets/src/mask.rs : 292
 		*byte ^= key[(index + offset) % key.len()];
 	lea ebx, [rcx + r11]
 	and ebx, 3
@@ -86,134 +82,50 @@ tokio_websockets::mask::imp::frame:
 		($this:ident, $len:ident => $zst_body:expr, $end:ident => $other_body:expr,) => {{
 	jne .LBB5_5
 .LBB5_6:
-		// /home/jens/tokio-websockets/src/mask.rs : 126
+		// /home/jens/tokio-websockets/src/mask.rs : 132
 		offset = (offset + prefix.len()) % key.len();
-	add edx, ecx
-	and edx, 3
-		// /home/jens/tokio-websockets/src/mask.rs : 128
+	add rdx, rcx
+		// /home/jens/tokio-websockets/src/mask.rs : 134
 		if !aligned_data.is_empty() {
-	test r9, r9
+	test r10, r10
 	je .LBB5_7
-	test rdx, rdx
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 70
-		if (right == 0) || (left == 0) {
-	je .LBB5_23
-	mov ecx, 4
-	sub rcx, rdx
-	mov rsi, rcx
-	mov r11, rcx
-	jmp .LBB5_13
-	.p2align	4, 0x90
-.LBB5_14:
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 129
-		i += right;
-	add r11, rcx
-.LBB5_13:
-	mov ebx, edi
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1385
-		crate::intrinsics::read_via_copy(src)
-	movzx edi, byte ptr [rsp + r11 - 12]
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1587
-		intrinsics::write_via_move(dst, src)
-	mov byte ptr [rsp + r11 - 12], bl
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 115
-		if i >= left {
-	mov rbx, r11
-	sub rbx, rdx
-	jb .LBB5_14
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 117
-		if i == 0 {
-	je .LBB5_16
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 125
-		if i < gcd {
-	cmp rbx, rsi
-	cmovb rsi, rbx
-	mov r11, rbx
-	jmp .LBB5_13
-.LBB5_16:
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1587
-		intrinsics::write_via_move(dst, src)
-	mov byte ptr [rsp - 12], dil
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1720
-		fn lt(&self, other: &$t) -> bool { (*self) < (*other) }
-	cmp rsi, 2
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/range.rs : 764
-		if self.start < self.end {
-	jb .LBB5_23
-	mov edi, 1
-	.p2align	4, 0x90
-.LBB5_18:
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1385
-		crate::intrinsics::read_via_copy(src)
-	movzx r11d, byte ptr [rsp + rdi - 12]
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 144
-		i = start + right;
-	lea rbx, [rdi + rcx]
-	jmp .LBB5_19
-	.p2align	4, 0x90
-.LBB5_20:
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 156
-		i += right;
-	add rbx, rcx
-.LBB5_19:
-	mov ebp, r11d
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1385
-		crate::intrinsics::read_via_copy(src)
-	movzx r11d, byte ptr [rsp + rbx - 12]
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1587
-		intrinsics::write_via_move(dst, src)
-	mov byte ptr [rsp + rbx - 12], bpl
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 148
-		if i >= left {
-	mov r14, rbx
-	sub r14, rdx
-	jb .LBB5_20
-	mov rbx, r14
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/rotate.rs : 150
-		if i == start {
-	cmp r14, rdi
-	jne .LBB5_19
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs : 1587
-		intrinsics::write_via_move(dst, src)
-	mov byte ptr [rsp + rdi - 12], r11b
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/uint_macros.rs : 572
-		intrinsics::unchecked_add(self, rhs)
-	inc rdi
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/cmp.rs : 1720
-		fn lt(&self, other: &$t) -> bool { (*self) < (*other) }
-	cmp rdi, rsi
-		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/range.rs : 764
-		if self.start < self.end {
-	jne .LBB5_18
-.LBB5_23:
-		// /home/jens/tokio-websockets/src/mask.rs : 131
-		let mask = _mm_set1_epi32(i32::from_le_bytes(key));
-	mov edi, dword ptr [rsp - 12]
+		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/uint_macros.rs : 307
+		intrinsics::bswap(self as $ActualT) as Self
+	mov esi, edi
+	bswap esi
+		// /home/jens/tokio-websockets/src/mask.rs : 138
+		.rotate_left(offset as u32 * u8::BITS)
+	lea ecx, [8*rdx]
+		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/uint_macros.rs : 261
+		return intrinsics::rotate_left(self, n);
+	rol esi, cl
+		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/num/uint_macros.rs : 307
+		intrinsics::bswap(self as $ActualT) as Self
+	bswap esi
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/../../stdarch/crates/core_arch/src/simd.rs : 18
 		$id([$($param_name),*])
-	movd xmm0, edi
+	movd xmm0, esi
 	pshufd xmm0, xmm0, 0
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/iter/macros.rs : 25
 		($this:ident, $len:ident => $zst_body:expr, $end:ident => $other_body:expr,) => {{
-	shl r9, 4
-	xor edx, edx
+	shl r10, 4
 	xor ecx, ecx
 	.p2align	4, 0x90
-.LBB5_24:
-	movdqa xmm1, xmmword ptr [r10 + rcx]
+.LBB5_12:
+	movdqa xmm1, xmmword ptr [r9 + rcx]
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/../../stdarch/crates/core_arch/src/x86/sse2.rs : 832
 		simd_xor(a, b)
 	pxor xmm1, xmm0
-		// /home/jens/tokio-websockets/src/mask.rs : 134
+		// /home/jens/tokio-websockets/src/mask.rs : 143
 		*block = _mm_xor_si128(*block, mask);
-	movdqa xmmword ptr [r10 + rcx], xmm1
+	movdqa xmmword ptr [r9 + rcx], xmm1
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs : 1584
 		self.as_ptr() == other.as_ptr()
 	add rcx, 16
-	cmp r9, rcx
+	cmp r10, rcx
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/iter/macros.rs : 25
 		($this:ident, $len:ident => $zst_body:expr, $end:ident => $other_body:expr,) => {{
-	jne .LBB5_24
+	jne .LBB5_12
 .LBB5_7:
 	mov dword ptr [rsp - 4], edi
 		// /home/jens/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs : 1584
@@ -225,7 +137,7 @@ tokio_websockets::mask::imp::frame:
 	xor ecx, ecx
 	.p2align	4, 0x90
 .LBB5_9:
-		// /home/jens/tokio-websockets/src/mask.rs : 278
+		// /home/jens/tokio-websockets/src/mask.rs : 292
 		*byte ^= key[(index + offset) % key.len()];
 	lea esi, [rdx + rcx]
 	and esi, 3
@@ -242,12 +154,8 @@ tokio_websockets::mask::imp::frame:
 		($this:ident, $len:ident => $zst_body:expr, $end:ident => $other_body:expr,) => {{
 	jne .LBB5_9
 .LBB5_10:
-		// /home/jens/tokio-websockets/src/mask.rs : 141
+		// /home/jens/tokio-websockets/src/mask.rs : 150
 		}
 	pop rbx
-	.cfi_def_cfa_offset 24
-	pop r14
-	.cfi_def_cfa_offset 16
-	pop rbp
 	.cfi_def_cfa_offset 8
 	ret
```

</details>

Program to showcase correctness:

```rs
fn main() {
    let a = [1, 2, 3, 4];

    let mut b = a.clone();
    b.rotate_left(3);
    let b = i32::from_ne_bytes(b);
    println!("{b}");

    let c = i32::from_be_bytes(a).rotate_left(3 * u8::BITS).to_be();
    println!("{c}");
}
```

This prints the same numbers on both x86_64 (little endian) and s390x (big endian) and shows the implementation is correct.

Further, the non-SIMD fallback is optimized to mask 8 bytes at once instead of just 1.