### PR TITLE
Get rid of PayloadStorage in favor of using Bytes::try_into_mut

### DIFF
--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -80,12 +80,6 @@ pub struct WebSocketStream<T> {
     pending_bytes: usize,
 }
 
-// SAFETY: The only !Sync field in `WebSocketStream` is `frame_queue`.
-// `frame_queue` must be used with exclusive, mutable access, which is
-// currently the case. It is only used in methods that take `&mut self`
-// and not borrowed in the methods.
-unsafe impl<T> Sync for WebSocketStream<T> {}
-
 impl<T> WebSocketStream<T>
 where
     T: AsyncRead + AsyncWrite + Unpin,

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -233,10 +233,7 @@ impl From<Payload> for Bytes {
 
 impl From<Payload> for BytesMut {
     fn from(value: Payload) -> Self {
-        match value.data.try_into_mut() {
-            Ok(b) => b,
-            Err(b) => b.into(),
-        }
+        value.data.into()
     }
 }
 

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -147,13 +147,10 @@ impl TryFrom<u16> for CloseCode {
 ///
 /// Payloads can be created by using the `From<T>` implementations.
 ///
-/// Sending the payloads is zero-copy, except when sending a payload created
-/// from a static slice or when the payload buffer is not unique.
+/// Sending the payloads or calling [`Into<BytesMut>`] is zero-copy, except when
+/// sending a payload created from a static slice or when the payload buffer is
+/// not unique. All conversions to other types are zero-cost.
 ///
-/// All conversions to other types are zero-cost, except [`Into<BytesMut>`] if
-/// the backing type is [`Bytes`] with a reference counter greater than one.
-///
-/// [`From<Bytes>`]: #impl-From<Bytes>-for-Payload
 /// [`Into<BytesMut>`]: #impl-From<Payload>-for-BytesMut
 #[derive(Clone)]
 pub struct Payload {


### PR DESCRIPTION
We can just always store the `Bytes` and use `try_into_mut` when necessary. This lets us drop the `UnsafeCell` and the `PayloadStorage` enum in favor of relying on bytes' correctness when tracking uniqueness.