### PR TITLE
Make encoded frame smaller

### DIFF
--- a/src/mask.rs
+++ b/src/mask.rs
@@ -345,9 +345,10 @@ fn test_mask() {
     // Mess around with the data to ensure we have unaligned input
     let mut data = data[2..998].to_vec();
     let mut data_clone = data.clone();
-    let key = get_mask();
-    frame(key, &mut data, 0);
-    one_byte_at_once(key, &mut data_clone, 0);
+    let mut mask = [0; 4];
+    get_mask(&mut mask);
+    frame(mask, &mut data, 0);
+    one_byte_at_once(mask, &mut data_clone, 0);
 
     assert_eq!(&data, &data_clone);
 }

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -18,10 +18,10 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::{codec::FramedRead, io::poll_write_buf};
 
 #[cfg(any(feature = "client", feature = "server"))]
-use super::types::Limits;
+use super::types::{Limits, Role};
 use super::{
     codec::WebSocketProtocol,
-    types::{Frame, Message, OpCode, Payload, Role, StreamState},
+    types::{Frame, Message, OpCode, Payload, StreamState},
     Config,
 };
 use crate::{CloseCode, Error};
@@ -238,41 +238,28 @@ where
     }
 
     /// Masks and queues a frame for sending when [`poll_flush`] gets called.
-    fn queue_frame(&mut self, frame: Frame) {
+    fn queue_frame(
+        &mut self,
+        #[cfg_attr(not(feature = "client"), allow(unused_mut))] mut frame: Frame,
+    ) {
         if frame.opcode == OpCode::Close && self.state != StreamState::ClosedByPeer {
             self.state = StreamState::ClosedByUs;
         }
 
-        let is_client = self.inner.decoder().role == Role::Client;
+        #[cfg_attr(not(feature = "client"), allow(unused_variables))]
+        let mask = frame.encode(&mut self.header_buf);
 
-        let (frame, mask): (Frame, [u8; 4]) = if is_client {
-            #[cfg(feature = "client")]
-            {
-                let mut frame = frame;
+        #[cfg(feature = "client")]
+        {
+            if self.inner.decoder().role == Role::Client {
                 let mut payload = BytesMut::from(frame.payload);
-                let mask = crate::rand::get_mask();
-                crate::mask::frame(mask, &mut payload, 0);
+                crate::rand::get_mask(mask);
+                crate::mask::frame(*mask, &mut payload, 0);
                 frame.payload = Payload::from(payload);
-
-                (frame, mask)
+                self.header_buf[1] |= 1 << 7;
             }
-            #[cfg(not(feature = "client"))]
-            {
-                // SAFETY: This allows for making the dependency on random generators
-                // only required for clients, servers can avoid it entirely.
-                // Since it is not possible to create a stream with client role
-                // without the client builder (and that is locked behind the client feature),
-                // this branch is impossible to reach.
-                unsafe { std::hint::unreachable_unchecked() }
-            }
-        } else {
-            (frame, [0, 0, 0, 0])
-        };
-
-        frame.encode(&mut self.header_buf, mask);
-        if is_client {
-            self.header_buf[1] |= 1 << 7;
         }
+
         let item = EncodedFrame {
             header: self.header_buf,
             payload: frame.payload,

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -31,8 +31,6 @@ use crate::{CloseCode, Error};
 struct EncodedFrame {
     /// Encoded frame header.
     header: [u8; 10],
-    /// Length of the header.
-    header_len: u8,
     /// Mask that the payload was masked with.
     mask: [u8; 4],
     /// Potentially masked message payload, ready for writing to the I/O.
@@ -44,6 +42,16 @@ impl EncodedFrame {
     #[inline]
     fn is_masked(&self) -> bool {
         self.header[1] >> 7 != 0
+    }
+
+    /// Returns the length of the header in bytes.
+    #[inline]
+    fn header_len(&self) -> usize {
+        match self.header[1] & 127 {
+            127 => 10,
+            126 => 4,
+            _ => 2,
+        }
     }
 }
 
@@ -262,18 +270,18 @@ where
             (frame, [0, 0, 0, 0])
         };
 
-        let header_len = frame.encode(&mut self.header_buf);
+        frame.encode(&mut self.header_buf);
         if is_client {
             self.header_buf[1] |= 1 << 7;
         }
-        self.pending_bytes +=
-            header_len as usize + (u8::from(is_client) * 4) as usize + frame.payload.len();
-        self.frame_queue.push_back(EncodedFrame {
+        let item = EncodedFrame {
             header: self.header_buf,
-            header_len,
             mask,
             payload: frame.payload,
-        });
+        };
+        self.pending_bytes +=
+            item.header_len() + (u8::from(is_client) * 4) as usize + item.payload.len();
+        self.frame_queue.push_back(item);
     }
 }
 
@@ -367,7 +375,7 @@ where
         let pending_bytes = &mut this.pending_bytes;
 
         while let Some(frame) = frame_queue.front() {
-            let frame_header = unsafe { frame.header.get_unchecked(..frame.header_len as usize) };
+            let frame_header = unsafe { frame.header.get_unchecked(..frame.header_len()) };
             let mut buf = frame_header
                 .chain(
                     frame

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -629,22 +629,19 @@ impl Frame {
         payload: Payload::from_static(&CloseCode::NORMAL_CLOSURE.0.get().to_be_bytes()),
     };
 
-    /// Encode the frame head into `out`, returning how many bytes were written.
-    pub fn encode(&self, out: &mut [u8; 10]) -> u8 {
+    /// Encode the frame head into `out`.
+    pub fn encode(&self, out: &mut [u8; 10]) {
         out[0] = (u8::from(self.is_final) << 7) | u8::from(self.opcode);
         if u16::try_from(self.payload.len()).is_err() {
             out[1] = 127;
             let len = u64::try_from(self.payload.len()).unwrap();
             out[2..10].copy_from_slice(&len.to_be_bytes());
-            10
         } else if self.payload.len() > 125 {
             out[1] = 126;
             let len = u16::try_from(self.payload.len()).expect("checked by previous branch");
             out[2..4].copy_from_slice(&len.to_be_bytes());
-            4
         } else {
             out[1] = u8::try_from(self.payload.len()).expect("checked by previous branch");
-            2
         }
     }
 }

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -630,19 +630,23 @@ impl Frame {
     };
 
     /// Encode the frame head into `out`.
-    pub fn encode(&self, out: &mut [u8; 10]) {
+    pub fn encode(&self, out: &mut [u8; 14], mask: [u8; 4]) {
         out[0] = (u8::from(self.is_final) << 7) | u8::from(self.opcode);
-        if u16::try_from(self.payload.len()).is_err() {
+        let start = if u16::try_from(self.payload.len()).is_err() {
             out[1] = 127;
             let len = u64::try_from(self.payload.len()).unwrap();
             out[2..10].copy_from_slice(&len.to_be_bytes());
+            10
         } else if self.payload.len() > 125 {
             out[1] = 126;
             let len = u16::try_from(self.payload.len()).expect("checked by previous branch");
             out[2..4].copy_from_slice(&len.to_be_bytes());
+            4
         } else {
             out[1] = u8::try_from(self.payload.len()).expect("checked by previous branch");
-        }
+            2
+        };
+        out[start..start + 4].copy_from_slice(&mask);
     }
 }
 

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -629,24 +629,26 @@ impl Frame {
         payload: Payload::from_static(&CloseCode::NORMAL_CLOSURE.0.get().to_be_bytes()),
     };
 
-    /// Encode the frame head into `out`.
-    pub fn encode(&self, out: &mut [u8; 14], mask: [u8; 4]) {
+    /// Encode the frame head into `out`, returning a subslice where the mask
+    /// should be written to.
+    pub fn encode<'a>(&self, out: &'a mut [u8; 14]) -> &'a mut [u8; 4] {
         out[0] = (u8::from(self.is_final) << 7) | u8::from(self.opcode);
-        let start = if u16::try_from(self.payload.len()).is_err() {
+        let mask_slice = if u16::try_from(self.payload.len()).is_err() {
             out[1] = 127;
             let len = u64::try_from(self.payload.len()).unwrap();
             out[2..10].copy_from_slice(&len.to_be_bytes());
-            10
+            &mut out[10..14]
         } else if self.payload.len() > 125 {
             out[1] = 126;
             let len = u16::try_from(self.payload.len()).expect("checked by previous branch");
             out[2..4].copy_from_slice(&len.to_be_bytes());
-            4
+            &mut out[4..8]
         } else {
             out[1] = u8::try_from(self.payload.len()).expect("checked by previous branch");
-            2
+            &mut out[2..6]
         };
-        out[start..start + 4].copy_from_slice(&mask);
+        // SAFETY: All ranges are exactly 4 bytes long
+        unsafe { mask_slice.try_into().unwrap_unchecked() }
     }
 }
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -16,8 +16,8 @@ mod imp {
     }
 
     /// Generate a random 4-byte WebSocket mask.
-    pub fn get_mask() -> [u8; 4] {
-        fastrand::u32(..).to_ne_bytes()
+    pub fn get_mask(dst: &mut [u8; 4]) {
+        fastrand::fill(dst);
     }
 }
 
@@ -33,10 +33,8 @@ mod imp {
     }
 
     /// Generate a random 4-byte WebSocket mask.
-    pub fn get_mask() -> [u8; 4] {
-        let mut bytes = [0; 4];
-        getrandom::fill(&mut bytes).expect("Failed to get random bytes, consider using `rand` or `fastrand` instead of `getrandom` if this persists");
-        bytes
+    pub fn get_mask(dst: &mut [u8; 4]) {
+        getrandom::fill(dst).expect("Failed to get random bytes, consider using `rand` or `fastrand` instead of `getrandom` if this persists");
     }
 }
 
@@ -53,10 +51,8 @@ mod imp {
     }
 
     /// Generate a random 4-byte WebSocket mask.
-    pub fn get_mask() -> [u8; 4] {
-        let mut bytes = [0; 4];
-        rand::thread_rng().fill_bytes(&mut bytes);
-        bytes
+    pub fn get_mask(dst: &mut [u8; 4]) {
+        rand::thread_rng().fill_bytes(dst);
     }
 }
 


### PR DESCRIPTION
This saves a bit of memory for every frame queued up. We can remove the option and the length field because the information necessary is stored in the header anyways.

By merging the header and the mask, the client will use 2 I/O slices rather than 3. This may or may not have a positive performance impact.

Finally, we directly write the mask to the header buffer, which simplifies the code a fair bit.