### PR TITLE
Reduce amount of unsafe code

### DIFF
--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -14,18 +14,16 @@ async fn run() -> Result<(), Error> {
         let (conn, _) = listener.accept().await?;
 
         tokio::spawn(tokio::task::unconstrained(async move {
-            let (_request, mut server) = unsafe {
-                ServerBuilder::new()
-                    .config(Config::default().frame_size(usize::MAX))
-                    .limits(Limits::unlimited())
-                    .accept(conn)
-                    .await
-                    .unwrap_unchecked()
-            };
+            let (_request, mut server) = ServerBuilder::new()
+                .config(Config::default().frame_size(usize::MAX))
+                .limits(Limits::unlimited())
+                .accept(conn)
+                .await
+                .unwrap();
 
             while let Some(Ok(item)) = server.next().await {
                 if item.is_text() || item.is_binary() {
-                    unsafe { server.send(item).await.unwrap_unchecked() };
+                    server.send(item).await.unwrap();
                 }
             }
         }));
@@ -33,12 +31,10 @@ async fn run() -> Result<(), Error> {
 }
 
 fn main() -> Result<(), Error> {
-    let rt = unsafe {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .build()
-            .unwrap_unchecked()
-    };
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
 
     rt.block_on(run())
 }

--- a/src/proto/codec.rs
+++ b/src/proto/codec.rs
@@ -6,7 +6,6 @@
 //! [`WebSocketStream`].
 //!
 //! [`WebSocketStream`]: super::WebSocketStream
-use std::hint::unreachable_unchecked;
 
 use bytes::{Buf, BytesMut};
 use tokio_util::codec::Decoder;
@@ -130,10 +129,9 @@ impl Decoder for WebSocketProtocol {
             if payload_length == 126 {
                 ensure_buffer_has_space!(src, offset + 2);
                 // SAFETY: The ensure_buffer_has_space call has validated this
-                // A conversion from two u8s to a u16 cannot fail
-                payload_length = u16::from_be_bytes(unsafe {
-                    src.get_unchecked(2..4).try_into().unwrap_unchecked()
-                }) as usize;
+                payload_length =
+                    u16::from_be_bytes(unsafe { src.get_unchecked(2..4).try_into().unwrap() })
+                        as usize;
                 if payload_length <= 125 {
                     return Err(Error::Protocol(ProtocolError::InvalidPayloadLength));
                 }
@@ -142,16 +140,15 @@ impl Decoder for WebSocketProtocol {
                 ensure_buffer_has_space!(src, offset + 8);
                 // SAFETY: The ensure_buffer_has_space call has validated this
                 // A conversion from 8 u8s to a u64 cannot fail
-                payload_length = u64::from_be_bytes(unsafe {
-                    src.get_unchecked(2..10).try_into().unwrap_unchecked()
-                }) as usize;
+                payload_length =
+                    u64::from_be_bytes(unsafe { src.get_unchecked(2..10).try_into().unwrap() })
+                        as usize;
                 if u16::try_from(payload_length).is_ok() {
                     return Err(Error::Protocol(ProtocolError::InvalidPayloadLength));
                 }
                 offset = 10;
             } else {
-                // SAFETY: Constructed from 7 bits so the max value is 127
-                unsafe { unreachable_unchecked() }
+                debug_assert!(false, "7 bit value expected to be <= 127");
             }
         }
 

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -4,7 +4,6 @@
 //! parameter.
 use std::{
     collections::VecDeque,
-    hint::unreachable_unchecked,
     io,
     mem::{replace, take},
     pin::Pin,
@@ -227,11 +226,9 @@ where
 
                     self.queue_frame(frame);
                 }
-                // SAFETY: match statement at the start of the method ensures that this is not the
-                // case
-                StreamState::ClosedByPeer | StreamState::CloseAcknowledged => unsafe {
-                    unreachable_unchecked()
-                },
+                StreamState::ClosedByPeer | StreamState::CloseAcknowledged => {
+                    debug_assert!(false, "unexpected StreamState");
+                }
                 StreamState::ClosedByUs => {
                     self.state = StreamState::CloseAcknowledged;
                 }

--- a/src/upgrade/client_request.rs
+++ b/src/upgrade/client_request.rs
@@ -20,8 +20,7 @@ fn contains_ignore_ascii_case(mut haystack: &[u8], needle: &[u8]) -> bool {
     }
 
     while haystack.len() >= needle.len() {
-        // SAFETY: needle.len() will always be equal to or less than haystack.len()
-        if unsafe { haystack.get_unchecked(..needle.len()) }.eq_ignore_ascii_case(needle) {
+        if haystack[..needle.len()].eq_ignore_ascii_case(needle) {
             return true;
         }
 

--- a/src/utf8.rs
+++ b/src/utf8.rs
@@ -84,8 +84,8 @@ impl Validator {
             unsafe {
                 self.partial_codepoint
                     .get_unchecked_mut(self.partial_codepoint_len..codepoint_len_after_copy)
-                    .copy_from_slice(input.get_unchecked(..bytes_to_copy));
             }
+            .copy_from_slice(&input[..bytes_to_copy]);
 
             // If we know that the codepoint is complete, we can use the basic variant
             if available_bytes >= missing_bytes {
@@ -120,7 +120,7 @@ impl Validator {
 
             self.reset();
 
-            unsafe { input.get_unchecked(bytes_to_copy..) }
+            &input[bytes_to_copy..]
         };
 
         // Validate the entire rest of the input


### PR DESCRIPTION
While auditing this crate I found it uses a lot of unsafe. In just a few minutes I found some bad uses of it, or cases in which the optimizer should easily be able to generate the same exact assembly from checked code. This removes those cases.
