### PR TITLE
fix(stream): poll_close could in some cases block indefenitely

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ nightly = ["simdutf8/aarch64_neon_prefetch"]
 futures-util = { version = "0.3.14", default-features = false, features = ["sink"] }
 rustls-pemfile = "2"
 rustls-pki-types = "1"
-tokio = { version = "1", default-features = false, features = ["net", "macros", "rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = ["net", "macros", "rt-multi-thread", "time"] }
 tokio-rustls = { version = "0.26", default-features = false }
 
 [[example]]

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -418,7 +418,7 @@ where
         if self.state == StreamState::Active {
             self.queue_frame(Frame::DEFAULT_CLOSE);
         }
-        while ready!(self.as_mut().poll_next(cx)).is_some() {}
+        while ready!(self.as_mut().poll_next(cx)).is_some_and(|r| r.is_ok()) {}
 
         ready!(self.as_mut().poll_flush(cx))?;
         Pin::new(self.inner.get_mut())

--- a/tests/pr102_regression.rs
+++ b/tests/pr102_regression.rs
@@ -1,0 +1,32 @@
+#![cfg(all(feature = "client", feature = "server"))]
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::{io::duplex, time::timeout};
+use tokio_websockets::{ClientBuilder, Message, ServerBuilder};
+
+#[tokio::test]
+async fn test_pr102_regression() {
+    let (tx, rx) = duplex(64);
+
+    // Create a server that sends a close message and immediately closes the
+    // connection
+    let mut server = ServerBuilder::new().serve(rx);
+    // Don't use ws.close() here to avoid a graceful handshake
+    server.send(Message::close(None, "")).await.unwrap();
+    // This will close the connection
+    drop(server);
+
+    // Create a client and make sure the close frame from the server was sent and
+    // the connection closed
+    let mut client = ClientBuilder::new().take_over(tx);
+
+    // Receive the close frame, this will queue the close ack frame
+    assert!(client.next().await.unwrap().unwrap().is_close());
+    // The close ack frame is queued, the connection is closed, before PR 102 this
+    // would trigger an infinite loop in close()
+    // For the regression test, fail the test if this doesn't close within a second
+    assert!(timeout(Duration::from_secs(1), client.close())
+        .await
+        .is_ok());
+}


### PR DESCRIPTION
In some cases poll_close would enter a indefenite loop since the error would stay.

Possibly related to https://github.com/twilight-rs/twilight/issues/2380.