### PR TITLE
Allows accessing websocket limits with interior mutability

### DIFF
--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -21,7 +21,7 @@ use super::types::{Limits, Role};
 use super::{
     codec::WebSocketProtocol,
     types::{Frame, Message, OpCode, Payload, StreamState},
-    Config,
+    Config, Limits,
 };
 use crate::{CloseCode, Error};
 
@@ -157,6 +157,16 @@ where
     /// corrupting the stream of frames.
     pub fn get_mut(&mut self) -> &mut T {
         self.inner.get_mut()
+    }
+
+    /// Returns a reference to the inner websocket limits.
+    pub fn limits(&self) -> &Limits {
+        &self.inner.decoder().limits
+    }
+
+    /// Returns a mutable reference to the inner websocket limits.
+    pub fn limits_mut(&mut self) -> &mut Limits {
+        &mut self.inner.decoder_mut().limits
     }
 
     /// Attempt to pull out the next frame from the [`Framed`] this stream and

--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -529,8 +529,7 @@ impl Iterator for MessageFrames {
 /// [`WebSocketStream`]: super::WebSocketStream
 #[derive(Debug, Clone, Copy)]
 pub struct Limits {
-    /// The maximum allowed payload length. The default
-    /// is 64 MiB.
+    /// The maximum allowed payload length. The default is 64 MiB.
     pub(super) max_payload_len: usize,
 }
 
@@ -543,13 +542,19 @@ impl Limits {
         }
     }
 
-    /// Sets the maximum allowed payload length. `None` equals no limit. The
-    /// default is 64 MiB.
+    /// Sets the maximum allowed payload length. `None` equals no limit.
+    ///
+    /// The default is 64 MiB.
     #[must_use]
     pub fn max_payload_len(mut self, size: Option<usize>) -> Self {
-        self.max_payload_len = size.unwrap_or(usize::MAX);
+        self.set_max_payload_len(size);
 
         self
+    }
+
+    /// See [`max_payload_len`](Self::max_payload_len).
+    pub fn set_max_payload_len(&mut self, size: Option<usize>) {
+        self.max_payload_len = size.unwrap_or(usize::MAX);
     }
 }
 


### PR DESCRIPTION
This PR introduces interior mutability for WebSocket limits, enabling applications to adjust them after the handshake. This is useful in scenarios where a connection starts with restrictive limits and later increases them based on application-layer validation of the peer.

Previously, WebSocket limits were immutable once a connection was established, making it difficult to adapt limits dynamically.

Since a WebSocket stream may be passed to a generic function as a `Stream` or `Sink`, type erasure could otherwise prevent access to the limits. Using `Arc` ensures that limits remain accessible and modifiable even when the stream is consumed generically.