### PR TITLE
Rotate masking key in-place

### DIFF
--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -33,8 +33,7 @@ async fn run_test(case: u32) -> Result<(), Error> {
     println!("Running test case {case}");
 
     let uri = Uri::from_str(&format!(
-        "ws://localhost:9001/runCase?case={}&agent=tokio-websockets",
-        case,
+        "ws://localhost:9001/runCase?case={case}&agent=tokio-websockets",
     ))
     .unwrap();
 

--- a/examples/rustls_server.rs
+++ b/examples/rustls_server.rs
@@ -67,7 +67,7 @@ async fn main() -> io::Result<()> {
 
         tokio::spawn(async move {
             if let Err(err) = fut.await {
-                eprintln!("{:?}", err);
+                eprintln!("{err:?}");
             }
         });
     }

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -19,16 +19,13 @@
 
 /// (Un-)masks input bytes with the framing key using AVX512.
 ///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
-///
 /// This will use a fallback implementation for less than 64 bytes. For
 /// sufficiently large inputs, it masks in chunks of 64 bytes per
 /// instruction, applying the fallback method on all remaining data.
 #[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
 #[allow(clippy::incompatible_msrv)] // nightly feature gated, stable since 1.89.0
 #[target_feature(enable = "avx512f")]
-unsafe fn frame_avx512(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+unsafe fn frame_avx512(key: &mut [u8; 4], input: &mut [u8]) {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{__m512i, _mm512_set1_epi32, _mm512_xor_si512};
     #[cfg(target_arch = "x86_64")]
@@ -38,16 +35,12 @@ unsafe fn frame_avx512(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         let (prefix, aligned_data, suffix) = input.align_to_mut::<__m512i>();
 
         // Run fallback implementation on unaligned prefix data
-        fallback_frame(key, prefix, offset);
-        offset = (offset + prefix.len()) % key.len();
+        if !prefix.is_empty() {
+            fallback_frame(key, prefix);
+        }
 
         if !aligned_data.is_empty() {
-            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-            let mask = _mm512_set1_epi32(
-                i32::from_be_bytes(key)
-                    .rotate_left(offset as u32 * u8::BITS)
-                    .to_be(),
-            );
+            let mask = _mm512_set1_epi32(i32::from_ne_bytes(*key));
 
             for block in aligned_data {
                 *block = _mm512_xor_si512(*block, mask);
@@ -55,21 +48,20 @@ unsafe fn frame_avx512(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         }
 
         // Run fallback implementation on unaligned suffix data
-        fallback_frame(key, suffix, offset);
+        if !suffix.is_empty() {
+            fallback_frame(key, suffix);
+        }
     }
 }
 
 /// (Un-)masks input bytes with the framing key using AVX2.
-///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
 ///
 /// This will use a fallback implementation for less than 32 bytes. For
 /// sufficiently large inputs, it masks in chunks of 32 bytes per
 /// instruction, applying the fallback method on all remaining data.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
-unsafe fn frame_avx2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+unsafe fn frame_avx2(key: &mut [u8; 4], input: &mut [u8]) {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{__m256i, _mm256_set1_epi32, _mm256_xor_si256};
     #[cfg(target_arch = "x86_64")]
@@ -79,16 +71,12 @@ unsafe fn frame_avx2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         let (prefix, aligned_data, suffix) = input.align_to_mut::<__m256i>();
 
         // Run fallback implementation on unaligned prefix data
-        fallback_frame(key, prefix, offset);
-        offset = (offset + prefix.len()) % key.len();
+        if !prefix.is_empty() {
+            fallback_frame(key, prefix);
+        }
 
         if !aligned_data.is_empty() {
-            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-            let mask = _mm256_set1_epi32(
-                i32::from_be_bytes(key)
-                    .rotate_left(offset as u32 * u8::BITS)
-                    .to_be(),
-            );
+            let mask = _mm256_set1_epi32(i32::from_ne_bytes(*key));
 
             for block in aligned_data {
                 *block = _mm256_xor_si256(*block, mask);
@@ -96,21 +84,20 @@ unsafe fn frame_avx2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         }
 
         // Run fallback implementation on unaligned suffix data
-        fallback_frame(key, suffix, offset);
+        if !suffix.is_empty() {
+            fallback_frame(key, suffix);
+        }
     }
 }
 
 /// (Un-)masks input bytes with the framing key using SSE2.
-///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
 ///
 /// This will use a fallback implementation for less than 16 bytes. For
 /// sufficiently large inputs, it masks in chunks of 16 bytes per
 /// instruction, applying the fallback method on all remaining data.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "sse2")]
-unsafe fn frame_sse2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+unsafe fn frame_sse2(key: &mut [u8; 4], input: &mut [u8]) {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::{__m128i, _mm_set1_epi32, _mm_xor_si128};
     #[cfg(target_arch = "x86_64")]
@@ -120,16 +107,12 @@ unsafe fn frame_sse2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         let (prefix, aligned_data, suffix) = input.align_to_mut::<__m128i>();
 
         // Run fallback implementation on unaligned prefix data
-        fallback_frame(key, prefix, offset);
-        offset = (offset + prefix.len()) % key.len();
+        if !prefix.is_empty() {
+            fallback_frame(key, prefix);
+        }
 
         if !aligned_data.is_empty() {
-            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-            let mask = _mm_set1_epi32(
-                i32::from_be_bytes(key)
-                    .rotate_left(offset as u32 * u8::BITS)
-                    .to_be(),
-            );
+            let mask = _mm_set1_epi32(i32::from_ne_bytes(*key));
 
             for block in aligned_data {
                 *block = _mm_xor_si128(*block, mask);
@@ -137,21 +120,20 @@ unsafe fn frame_sse2(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         }
 
         // Run fallback implementation on unaligned suffix data
-        fallback_frame(key, suffix, offset);
+        if !suffix.is_empty() {
+            fallback_frame(key, suffix);
+        }
     }
 }
 
 /// (Un-)masks input bytes with the framing key using NEON.
-///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
 ///
 /// This will use a fallback implementation for less than 16 bytes. For
 /// sufficiently large inputs, it masks in chunks of 16 bytes per
 /// instruction, applying the fallback method on all remaining data.
 #[cfg(any(all(feature = "nightly", target_arch = "arm"), target_arch = "aarch64"))]
 #[target_feature(enable = "neon")]
-unsafe fn frame_neon(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+unsafe fn frame_neon(key: &mut [u8; 4], input: &mut [u8]) {
     #[cfg(target_arch = "aarch64")]
     use std::arch::aarch64::{uint8x16_t, veorq_u8, vld1q_dup_s32, vreinterpretq_u8_s32};
     #[cfg(target_arch = "arm")]
@@ -161,16 +143,12 @@ unsafe fn frame_neon(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         let (prefix, aligned_data, suffix) = input.align_to_mut::<uint8x16_t>();
 
         // Run fallback implementation on unaligned prefix data
-        fallback_frame(key, prefix, offset);
-        offset = (offset + prefix.len()) % key.len();
+        if !prefix.is_empty() {
+            fallback_frame(key, prefix);
+        }
 
         if !aligned_data.is_empty() {
-            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-            let mask = vreinterpretq_u8_s32(vld1q_dup_s32(
-                &i32::from_be_bytes(key)
-                    .rotate_left(offset as u32 * u8::BITS)
-                    .to_be() as *const i32,
-            ));
+            let mask = vreinterpretq_u8_s32(vld1q_dup_s32(key.as_ptr() as *const i32));
 
             for block in aligned_data {
                 *block = veorq_u8(*block, mask);
@@ -178,14 +156,13 @@ unsafe fn frame_neon(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         }
 
         // Run fallback implementation on unaligned suffix data
-        fallback_frame(key, suffix, offset);
+        if !suffix.is_empty() {
+            fallback_frame(key, suffix);
+        }
     }
 }
 
 /// (Un-)masks input bytes with the framing key using AltiVec.
-///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
 ///
 /// This will use a fallback implementation for less than 16 bytes. For
 /// sufficiently large inputs, it masks in chunks of 16 bytes per
@@ -195,7 +172,7 @@ unsafe fn frame_neon(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     any(target_arch = "powerpc", target_arch = "powerpc64")
 ))]
 #[target_feature(enable = "altivec")]
-unsafe fn frame_altivec(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+unsafe fn frame_altivec(key: &mut [u8; 4], input: &mut [u8]) {
     #[cfg(target_arch = "powerpc")]
     use std::arch::powerpc::{vec_splats, vec_xor, vector_unsigned_char};
     #[cfg(target_arch = "powerpc64")]
@@ -206,17 +183,13 @@ unsafe fn frame_altivec(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         let (prefix, aligned_data, suffix) = input.align_to_mut::<vector_unsigned_char>();
 
         // Run fallback implementation on unaligned prefix data
-        fallback_frame(key, prefix, offset);
-        offset = (offset + prefix.len()) % key.len();
+        if !prefix.is_empty() {
+            fallback_frame(key, prefix);
+        }
 
         if !aligned_data.is_empty() {
             // SAFETY: 4x i32 to 16x u8 is safe
-            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-            let mask: vector_unsigned_char = transmute(vec_splats(
-                i32::from_be_bytes(key)
-                    .rotate_left(offset as u32 * u8::BITS)
-                    .to_be(),
-            ));
+            let mask: vector_unsigned_char = transmute(vec_splats(i32::from_ne_bytes(*key)));
 
             for block in aligned_data {
                 *block = vec_xor(*block, mask);
@@ -224,21 +197,20 @@ unsafe fn frame_altivec(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         }
 
         // Run fallback implementation on unaligned suffix data
-        fallback_frame(key, suffix, offset);
+        if !suffix.is_empty() {
+            fallback_frame(key, suffix);
+        }
     }
 }
 
 /// (Un-)masks input bytes with the framing key using s390x vectors.
-///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
 ///
 /// This will use a fallback implementation for less than 16 bytes. For
 /// sufficiently large inputs, it masks in chunks of 16 bytes per
 /// instruction, applying the fallback method on all remaining data.
 #[cfg(all(feature = "nightly", target_arch = "s390x"))]
 #[target_feature(enable = "vector")]
-unsafe fn frame_s390x_vector(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+unsafe fn frame_s390x_vector(key: &mut [u8; 4], input: &mut [u8]) {
     use std::{
         arch::s390x::{vec_splats, vec_xor, vector_signed_int, vector_unsigned_char},
         mem::transmute,
@@ -248,14 +220,14 @@ unsafe fn frame_s390x_vector(key: [u8; 4], input: &mut [u8], mut offset: usize) 
         let (prefix, aligned_data, suffix) = input.align_to_mut::<vector_unsigned_char>();
 
         // Run fallback implementation on unaligned prefix data
-        fallback_frame(key, prefix, offset);
-        offset = (offset + prefix.len()) % key.len();
+        if !prefix.is_empty() {
+            fallback_frame(key, prefix);
+        }
 
         if !aligned_data.is_empty() {
             // SAFETY: 4x i32 to 16x u8 is safe
-            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
             let mask: vector_unsigned_char = transmute(vec_splats::<i32, vector_signed_int>(
-                i32::from_be_bytes(key).rotate_left(offset as u32 * u8::BITS),
+                i32::from_ne_bytes(*key),
             ));
 
             for block in aligned_data {
@@ -264,21 +236,20 @@ unsafe fn frame_s390x_vector(key: [u8; 4], input: &mut [u8], mut offset: usize) 
         }
 
         // Run fallback implementation on unaligned suffix data
-        fallback_frame(key, suffix, offset);
+        if !suffix.is_empty() {
+            fallback_frame(key, suffix);
+        }
     }
 }
 
 /// (Un-)masks input bytes with the framing key using LASX.
-///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
 ///
 /// This will use a fallback implementation for less than 32 bytes. For
 /// sufficiently large inputs, it masks in chunks of 32 bytes per
 /// instruction, applying the fallback method on all remaining data.
 #[cfg(all(feature = "nightly", target_arch = "loongarch64"))]
 #[target_feature(enable = "lasx")]
-unsafe fn frame_lasx_vector(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+unsafe fn frame_lasx_vector(key: &mut [u8; 4], input: &mut [u8]) {
     use std::{
         arch::loongarch64::{lasx_xvld, lasx_xvxor_v, v32u8},
         mem::transmute,
@@ -288,17 +259,14 @@ unsafe fn frame_lasx_vector(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         let (prefix, aligned_data, suffix) = input.align_to_mut::<v32u8>();
 
         // Run fallback implementation on unaligned prefix data
-        fallback_frame(key, prefix, offset);
-        offset = (offset + prefix.len()) % key.len();
+        if !prefix.is_empty() {
+            fallback_frame(key, prefix);
+        }
 
         if !aligned_data.is_empty() {
-            #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-            let rotated_key = i32::from_be_bytes(key)
-                .rotate_left(offset as u32 * u8::BITS)
-                .to_be();
-            let rotated_key_vector = [rotated_key; 8];
+            let key_vector = [i32::from_ne_bytes(*key); 8];
             // SAFETY: 32x i8 to 32x u8 is safe
-            let mask: v32u8 = transmute(lasx_xvld::<0>(rotated_key_vector.as_ptr().cast()));
+            let mask: v32u8 = transmute(lasx_xvld::<0>(key_vector.as_ptr().cast()));
 
             for block in aligned_data {
                 *block = lasx_xvxor_v(*block, mask);
@@ -306,49 +274,45 @@ unsafe fn frame_lasx_vector(key: [u8; 4], input: &mut [u8], mut offset: usize) {
         }
 
         // Run fallback implementation on unaligned suffix data
-        fallback_frame(key, suffix, offset);
+        if !suffix.is_empty() {
+            fallback_frame(key, suffix);
+        }
     }
+}
+
+/// Rotates the mask in-place by a certain amount of bytes.
+#[allow(clippy::cast_possible_truncation)] // offset % 4 is within u32 bounds
+fn rotate_mask(key: &mut [u8; 4], offset: usize) {
+    *key = u32::from_be_bytes(*key)
+        .rotate_left((offset % key.len()) as u32 * u8::BITS)
+        .to_be_bytes();
 }
 
 /// (Un-)masks input bytes with the framing key, one byte at once.
 ///
 /// See [`fallback_frame`] for more details.
-fn one_byte_at_once(key: [u8; 4], input: &mut [u8], offset: usize) {
-    // This lets the compiler unroll the loop partially compared to adding the
-    // offset in the loop. The assembly is more readable this way and easier to
-    // reason about, performance wise it's roundabout the same because the compiler
-    // otherwise generates a garbled mess of special cases.
-    #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-    let key = i32::from_be_bytes(key)
-        .rotate_left(offset as u32 * u8::BITS)
-        .to_be_bytes();
-
+fn one_byte_at_once(key: &mut [u8; 4], input: &mut [u8]) {
     for (index, byte) in input.iter_mut().enumerate() {
         *byte ^= key[index % key.len()];
     }
+
+    rotate_mask(key, input.len());
 }
 
 /// (Un-)masks input bytes with the framing key.
 ///
-/// The input bytes may be further in the payload and therefore the offset into
-/// the payload must be specified.
-///
 /// This is used as the internal implementation in non-SIMD builds and as a
 /// fallback in SIMD builds.
-fn fallback_frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
+fn fallback_frame(key: &mut [u8; 4], input: &mut [u8]) {
     let (prefix, aligned_data, suffix) = unsafe { input.align_to_mut::<u64>() };
 
     // Run fallback implementation on unaligned prefix data
-    one_byte_at_once(key, prefix, offset);
-    offset = (offset + prefix.len()) % key.len();
+    if !prefix.is_empty() {
+        one_byte_at_once(key, prefix);
+    }
 
     if !aligned_data.is_empty() {
-        #[allow(clippy::cast_possible_truncation)] // offset is 0..4
-        let masking_key = u64::from(
-            u32::from_be_bytes(key)
-                .rotate_left(offset as u32 * u8::BITS)
-                .to_be(),
-        );
+        let masking_key = u64::from(u32::from_ne_bytes(*key));
         let mask = (masking_key << u32::BITS) | masking_key;
 
         for block in aligned_data {
@@ -357,28 +321,27 @@ fn fallback_frame(key: [u8; 4], input: &mut [u8], mut offset: usize) {
     }
 
     // Run fallback implementation on unaligned suffix data
-    one_byte_at_once(key, suffix, offset);
+    if !suffix.is_empty() {
+        one_byte_at_once(key, suffix);
+    }
 }
 
 /// (Un-)masks input bytes with the framing key.
-///
-/// The input bytes may be further in the payload and therefore the offset
-/// into the payload must be specified.
 #[inline]
-pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
+pub fn frame(key: &mut [u8; 4], input: &mut [u8]) {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
         use std::arch::is_x86_feature_detected;
 
         #[cfg(feature = "nightly")]
         if is_x86_feature_detected!("avx512f") {
-            return unsafe { frame_avx512(key, input, offset) };
+            return unsafe { frame_avx512(key, input) };
         }
 
         if is_x86_feature_detected!("avx2") {
-            return unsafe { frame_avx2(key, input, offset) };
+            return unsafe { frame_avx2(key, input) };
         } else if is_x86_feature_detected!("sse2") {
-            return unsafe { frame_sse2(key, input, offset) };
+            return unsafe { frame_sse2(key, input) };
         }
     }
 
@@ -387,7 +350,7 @@ pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
         use std::arch::is_arm_feature_detected;
 
         if is_arm_feature_detected!("neon") {
-            return unsafe { frame_neon(key, input, offset) };
+            return unsafe { frame_neon(key, input) };
         }
     }
 
@@ -396,7 +359,7 @@ pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
         use std::arch::is_aarch64_feature_detected;
 
         if is_aarch64_feature_detected!("neon") {
-            return unsafe { frame_neon(key, input, offset) };
+            return unsafe { frame_neon(key, input) };
         }
     }
 
@@ -405,7 +368,7 @@ pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
         use std::arch::is_powerpc_feature_detected;
 
         if is_powerpc_feature_detected!("altivec") {
-            return unsafe { frame_altivec(key, input, offset) };
+            return unsafe { frame_altivec(key, input) };
         }
     }
 
@@ -414,7 +377,7 @@ pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
         use std::arch::is_powerpc64_feature_detected;
 
         if is_powerpc64_feature_detected!("altivec") {
-            return unsafe { frame_altivec(key, input, offset) };
+            return unsafe { frame_altivec(key, input) };
         }
     }
 
@@ -423,7 +386,7 @@ pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
         use std::arch::is_s390x_feature_detected;
 
         if is_s390x_feature_detected!("vector") {
-            return unsafe { frame_s390x_vector(key, input, offset) };
+            return unsafe { frame_s390x_vector(key, input) };
         }
     }
 
@@ -432,11 +395,11 @@ pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
         use std::arch::is_loongarch_feature_detected;
 
         if is_loongarch_feature_detected!("lasx") {
-            return unsafe { frame_lasx_vector(key, input, offset) };
+            return unsafe { frame_lasx_vector(key, input) };
         }
     }
 
-    fallback_frame(key, input, offset);
+    fallback_frame(key, input);
 }
 
 #[cfg(all(test, feature = "client", feature = "fastrand"))]
@@ -444,16 +407,17 @@ pub fn frame(key: [u8; 4], input: &mut [u8], offset: usize) {
 fn test_mask() {
     use crate::rand::get_mask;
 
-    let data: Vec<u8> = std::iter::repeat_with(|| fastrand::u8(..))
+    let mut random_data: Vec<u8> = std::iter::repeat_with(|| fastrand::u8(..))
         .take(1024)
         .collect();
     // Mess around with the data to ensure we have unaligned input
-    let mut data = data[2..998].to_vec();
-    let mut data_clone = data.clone();
+    let data = &mut random_data[2..998];
+    let mut data_clone = data.to_vec();
     let mut mask = [0; 4];
     get_mask(&mut mask);
-    frame(mask, &mut data, 0);
-    one_byte_at_once(mask, &mut data_clone, 0);
+    let mut mask2 = mask;
+    frame(&mut mask, data);
+    one_byte_at_once(&mut mask2, &mut data_clone);
 
     assert_eq!(&data, &data_clone);
 }

--- a/src/proto/stream.rs
+++ b/src/proto/stream.rs
@@ -376,7 +376,12 @@ where
             if self.inner.decoder().role == Role::Client {
                 let mut payload = BytesMut::from(frame.payload);
                 crate::rand::get_mask(mask);
-                crate::mask::frame(*mask, &mut payload, 0);
+                // mask::frame will mutate the mask in-place, but we want to send the original
+                // mask. This is essentially a u32, so copying it is cheap and easier than
+                // special-casing this in the masking implementation.
+                // &mut *mask won't work, the compiler will optimize the deref/copy away
+                let mut mask_copy = *mask;
+                crate::mask::frame(&mut mask_copy, &mut payload);
                 frame.payload = Payload::from(payload);
                 self.header_buf[1] |= 1 << 7;
             }


### PR DESCRIPTION
Makes the code easier to reason about and gets rid of some duplicate logic.