### PR TITLE
Improve and extend CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,10 +226,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v5
 
-      - name: Install 1.89.0 toolchain
+      - name: Retrieve rust-version
+        run: echo rust-version=$(awk '/rust-version/{print $NF}' Cargo.toml | tr -d '"') >> $GITHUB_ENV
+
+      - name: Install toolchain (${{ env.rust-version }})
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.89.0
+          toolchain: ${{ env.rust-version }}
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,13 +215,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v5
 
-      - name: Install nightly toolchain
+      - name: Install 1.89.0 toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
-
-      - name: Get latest compatible dependencies for MSRV
-        run: CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
+          toolchain: 1.89.0
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v3
@@ -229,10 +226,8 @@ jobs:
           crate: cargo-hack
           locked: false
 
-      - name: Install 1.89.0 toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.89.0
+      - name: Get latest compatible dependencies for MSRV
+        run: CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo update
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,14 +204,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: x86_64
-            image: ubuntu-latest
+          # We want to cover all supported architectures here
+          # FIXME: Add armv7, ppc64, ppc64le
           - arch: aarch64
             image: ubuntu-24.04-arm
+          - arch: loongarch64
+            image: [alpine-edge, loongarch64]
+          - arch: s390x
+            image: [ubuntu-25.10, s390x]
+          - arch: x86_64
+            image: ubuntu-latest
 
     runs-on: ${{ matrix.image }}
 
     steps:
+      # Helpful for debugging and making sure our runners support the
+      # vector instructions we emit
+      - name: Show CPU information
+        run: lscpu
+
       - name: Checkout sources
         uses: actions/checkout@v5
 


### PR DESCRIPTION
This runs the MSRV cargo powerset checks on loongarch64 and s390x. Ideally we'll also want to run tests on these targets and check for minvers.