### PR TITLE
feat: allow configuring max num of HTTP headers during upgrade handshake

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -25,7 +25,7 @@ use crate::{
     Connector, Error, MaybeTlsStream, WebSocketStream,
     proto::{Config, Limits, Role},
     resolver::{self, Resolver},
-    upgrade::{self, server_response},
+    upgrade::{self, Handshake, server_response},
 };
 
 /// Generates a new, random 16-byte WebSocket key and encodes it as base64.
@@ -132,8 +132,8 @@ pub struct Builder<'a, R: Resolver = resolver::Gai> {
     config: Config,
     /// Limits to impose on the WebSocket stream.
     limits: Limits,
-    /// Headers to be sent with the upgrade request.
-    headers: HeaderMap,
+    /// Configuration for the HTTP upgrade handshake.
+    handshake: Handshake,
 }
 
 impl Builder<'_> {
@@ -147,7 +147,7 @@ impl Builder<'_> {
             resolver: resolver::Gai,
             config: Config::default(),
             limits: Limits::default(),
-            headers: HeaderMap::new(),
+            handshake: Handshake::default(),
         }
     }
 
@@ -163,7 +163,7 @@ impl Builder<'_> {
             resolver: resolver::Gai,
             config: Config::default(),
             limits: Limits::default(),
-            headers: HeaderMap::new(),
+            handshake: Handshake::default(),
         }
     }
 }
@@ -207,7 +207,7 @@ impl<'a, R: Resolver> Builder<'a, R> {
             resolver: _,
             config,
             limits,
-            headers,
+            handshake,
         } = self;
 
         Builder {
@@ -216,7 +216,7 @@ impl<'a, R: Resolver> Builder<'a, R> {
             resolver,
             config,
             limits,
-            headers,
+            handshake,
         }
     }
 
@@ -246,9 +246,18 @@ impl<'a, R: Resolver> Builder<'a, R> {
         if DISALLOWED_HEADERS.contains(&name) {
             return Err(Error::DisallowedHeader);
         }
-        self.headers.insert(name, value);
+        self.handshake.headers.insert(name, value);
 
         Ok(self)
+    }
+
+    /// Sets the maximum number of HTTP headers to parse from the server's
+    /// upgrade response. The default is 64.
+    #[must_use]
+    pub fn max_headers(mut self, max: usize) -> Self {
+        self.handshake.max_headers = max;
+
+        self
     }
 
     /// Establishes a connection to the WebSocket server. This requires a URI to
@@ -318,8 +327,8 @@ impl<'a, R: Resolver> Builder<'a, R> {
 
         let key_base64 = make_key();
 
-        let upgrade_codec = server_response::Codec::new(&key_base64);
-        let request = build_request(uri, &key_base64, &self.headers);
+        let upgrade_codec = server_response::Codec::new(&key_base64, self.handshake.max_headers);
+        let request = build_request(uri, &key_base64, &self.handshake.headers);
         stream.write_all(&request).await?;
         stream.flush().await?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,14 +8,14 @@
 use std::{future::poll_fn, io, pin::Pin};
 
 use futures_core::Stream;
-use http::{HeaderMap, HeaderName, HeaderValue, header};
+use http::{HeaderName, HeaderValue, header};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio_util::codec::FramedRead;
 
 use crate::{
     Error, WebSocketStream,
     proto::{Config, Limits, Role},
-    upgrade::client_request,
+    upgrade::{Handshake, client_request},
 };
 
 /// HTTP/1.1 400 Bad Request response payload.
@@ -40,8 +40,8 @@ pub struct Builder {
     config: Config,
     /// Limits to impose on the WebSocket stream.
     limits: Limits,
-    /// Headers to be sent with the switching protocols response.
-    headers: HeaderMap,
+    /// Configuration for the HTTP upgrade handshake.
+    handshake: Handshake,
 }
 
 impl Default for Builder {
@@ -58,7 +58,7 @@ impl Builder {
         Self {
             config: Config::default(),
             limits: Limits::default(),
-            headers: HeaderMap::new(),
+            handshake: Handshake::default(),
         }
     }
 
@@ -88,9 +88,18 @@ impl Builder {
         if DISALLOWED_HEADERS.contains(&name) {
             return Err(Error::DisallowedHeader);
         }
-        self.headers.insert(name, value);
+        self.handshake.headers.insert(name, value);
 
         Ok(self)
+    }
+
+    /// Sets the maximum number of HTTP headers to parse from the client's
+    /// upgrade request. The default is 64.
+    #[must_use]
+    pub fn max_headers(mut self, max: usize) -> Self {
+        self.handshake.max_headers = max;
+
+        self
     }
 
     /// Perform a HTTP upgrade handshake on an already established stream and
@@ -106,7 +115,7 @@ impl Builder {
         let mut framed = FramedRead::new(
             stream,
             client_request::Codec {
-                response_headers: &self.headers,
+                handshake: &self.handshake,
             },
         );
         let reply = poll_fn(|cx| Pin::new(&mut framed).poll_next(cx)).await;

--- a/src/upgrade/client_request.rs
+++ b/src/upgrade/client_request.rs
@@ -3,11 +3,14 @@ use std::str::FromStr;
 
 use base64::{Engine, engine::general_purpose::STANDARD};
 use bytes::{Buf, BytesMut};
-use http::{HeaderMap, header::SET_COOKIE};
+use http::header::SET_COOKIE;
 use httparse::Request;
 use tokio_util::codec::Decoder;
 
-use crate::{sha::digest, upgrade::Error};
+use crate::{
+    sha::digest,
+    upgrade::{Error, Handshake},
+};
 
 /// A static HTTP/1.1 101 Switching Protocols response up until the
 /// `Sec-WebSocket-Accept` header value.
@@ -96,8 +99,8 @@ impl ClientRequest {
 ///
 /// [`Encoder`]: tokio_util::codec::Encoder
 pub struct Codec<'a> {
-    /// List of headers to add to the Switching Protocols response.
-    pub response_headers: &'a HeaderMap,
+    /// Configuration for the HTTP upgrade handshake.
+    pub handshake: &'a Handshake,
 }
 
 impl Decoder for Codec<'_> {
@@ -105,7 +108,7 @@ impl Decoder for Codec<'_> {
     type Item = (http::Request<()>, Vec<u8>);
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        let mut headers = [httparse::EMPTY_HEADER; 64];
+        let mut headers = vec![httparse::EMPTY_HEADER; self.handshake.max_headers];
         let mut request = Request::new(&mut headers);
         let status = request.parse(src).map_err(Error::Parsing)?;
 
@@ -162,8 +165,8 @@ impl Decoder for Codec<'_> {
         resp.extend_from_slice(ws_accept.as_bytes());
         resp.extend_from_slice(b"\r\n");
 
-        for name in self.response_headers.keys() {
-            let values = self.response_headers.get_all(name).iter();
+        for name in self.handshake.headers.keys() {
+            let values = self.handshake.headers.get_all(name).iter();
 
             if name == SET_COOKIE {
                 // Set-Cookie is treated differently because if multiple values are present,

--- a/src/upgrade/mod.rs
+++ b/src/upgrade/mod.rs
@@ -1,10 +1,36 @@
 //! HTTP upgrade request and response generation and validation helpers.
 
 use std::fmt;
+
+use http::HeaderMap;
+
 #[cfg(feature = "server")]
 pub(crate) mod client_request;
 #[cfg(feature = "client")]
 pub(crate) mod server_response;
+
+/// The default maximum number of HTTP headers to parse during the upgrade
+/// handshake.
+const DEFAULT_MAX_HEADERS: usize = 64;
+
+/// Configuration for the HTTP upgrade handshake.
+#[derive(Debug, Clone)]
+pub(crate) struct Handshake {
+    /// Maximum number of HTTP headers to parse from the upgrade request or
+    /// response.
+    pub(crate) max_headers: usize,
+    /// Extra headers to include in the upgrade request or response.
+    pub(crate) headers: HeaderMap,
+}
+
+impl Default for Handshake {
+    fn default() -> Self {
+        Self {
+            max_headers: DEFAULT_MAX_HEADERS,
+            headers: HeaderMap::new(),
+        }
+    }
+}
 
 /// A parsed HTTP/1.1 101 Switching Protocols response.
 /// These responses typically do not contain a body, therefore it is omitted.

--- a/src/upgrade/server_response.rs
+++ b/src/upgrade/server_response.rs
@@ -31,6 +31,8 @@ fn header<'a, 'header: 'a>(
 pub struct Codec {
     /// The SHA-1 digest of the `Sec-WebSocket-Key` header.
     ws_accept: [u8; 20],
+    /// Maximum number of HTTP headers to parse.
+    max_headers: usize,
 }
 
 impl Codec {
@@ -39,9 +41,10 @@ impl Codec {
     /// The `key` parameter provides the string passed to the server via the
     /// HTTP `Sec-WebSocket-Key` header.
     #[must_use]
-    pub fn new(key: &[u8]) -> Self {
+    pub fn new(key: &[u8], max_headers: usize) -> Self {
         Self {
             ws_accept: digest(key),
+            max_headers,
         }
     }
 }
@@ -51,7 +54,7 @@ impl Decoder for Codec {
     type Item = super::Response;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        let mut headers = [httparse::EMPTY_HEADER; 25];
+        let mut headers = vec![httparse::EMPTY_HEADER; self.max_headers];
         let mut response = Response::new(&mut headers);
         let status = response.parse(src).map_err(Error::Parsing)?;
 


### PR DESCRIPTION
  ### Changes

- Added a  `max_headers(max: usize)`  method to both  `server::Builder`  and  `client::Builder` .
- Introduced an internal  `Handshake`  configuration struct to manage handshake-specific settings.
- Updated  `client_request::Codec`  and  `server_response::Codec`  to use a heap-allocated  `vec![httparse::EMPTY_HEADER; max_headers]`  instead of a fixed-size stack array for the  httparse  buffer.