### PR TITLE
Implement `PartialEq` and `Eq` for `Payload`

### DIFF
--- a/src/proto/types.rs
+++ b/src/proto/types.rs
@@ -190,6 +190,14 @@ impl fmt::Debug for Payload {
     }
 }
 
+impl PartialEq for Payload {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl Eq for Payload {}
+
 impl From<Bytes> for Payload {
     fn from(value: Bytes) -> Self {
         Self {


### PR DESCRIPTION
We only care about the equality of the actual data, so we look away from if it has been checked as Utf-8